### PR TITLE
Fix #44 Add persistency data to nodes.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source=pypeman
+omit=
+  **/tests/**
+  pypeman/pjt_templates.py
+  pypeman/default_settings.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 .idea
 .env
 .*.swp
+.envrc
+.vscode

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[TYPECHECK]
+generated-members=REQUEST,acl_users,aq_parent,objects,_meta,id

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -1,5 +1,5 @@
-Core concepts
-=============
+User guide
+==========
 
 One image is better than 100 words:
 
@@ -58,11 +58,22 @@ A node is a processing unit in a channel.
 To create a node, inherit form `pypeman.nodes.BaseNode` and
 override `process(msg)` method.
 
+You can use persistence storage to save data between two pypeman
+executions sush last time a specific channel ran by using the two
+following methods: :func:`save_data <pypeman.nodes.BaseNode.save_data>` and
+:func:`restore_data<pypeman.nodes.BaseNode.restore_data>`
+
 Specific nodes
 ``````````````
+Base for all node. You must inherit from this class if you want to create
+a new node for your project.
+
 ..  autoclass:: pypeman.nodes.BaseNode
     :members:
     :noindex:
+
+Thread node allow you to create node that execute is process method in another
+thread to avoid blocking nodes.
 
 ..  autoclass:: pypeman.nodes.ThreadNode
     :members:

--- a/pypeman/conf.py
+++ b/pypeman/conf.py
@@ -28,9 +28,12 @@ class ConfigError(ImportError):
 class Settings():
     """ pypeman projects settings. Rather similar implementations to django.conf.settings """
 
-    def __init__(self):
+    def __init__(self, module_name=None):
         self.__dict__['_settings_mod'] = None
-        self.__dict__['SETTINGS_MODULE'] = os.environ.get('PYPEMAN_SETTINGS_MODULE', 'settings')
+        if module_name:
+            self.__dict__['SETTINGS_MODULE'] = module_name
+        else:
+            self.__dict__['SETTINGS_MODULE'] = os.environ.get('PYPEMAN_SETTINGS_MODULE', 'settings')
 
     def init_settings(self):
         try:

--- a/pypeman/default_settings.py
+++ b/pypeman/default_settings.py
@@ -1,22 +1,25 @@
-#!/usr/bin/env python
+"""
+Default configuration file.
+This settings should be redifined.
+"""
 
 DEBUG = False   # bool. can be set by env var PYPEMAN_DEBUG (0|1|true|false) or pypeman cmd args
 TESTING = False # bool. can be set by env var PYPEMAN_TESTING (0|1|true|false) pypeman cmd args
 
 DEBUG_PARAMS = dict(
-    slow_callback_duration = 0.1
+    slow_callback_duration=0.1
 )
 
 HTTP_ENDPOINT_CONFIG = ['0.0.0.0', '8080']
 
-handlers = [ 'console' ]
+PERSISTENCE_BACKEND = None
+PERSISTENCE_CONFIG = {}
 
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            #'format': '%(levelname)s %(asctime)s %(name)s %(module)s %(process)d %(thread)d %(message)s'
             'format': '%(levelname)s %(asctime)s %(name)s %(module)s %(message)s'
         },
     },
@@ -29,10 +32,9 @@ LOGGING = {
     },
 
     'loggers': {
-        # root loggers
         '': {
             'level': 'INFO',
-            'handlers': handlers,
+            'handlers': ['console'],
         },
         'jsonrpcclient':{
             'level': 'WARNING',

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -80,6 +80,8 @@ class BaseNode:
     If you create a new node, you must inherit from this class and
     implement `process` method.
 
+    :func:`save_data <pypeman.nodes.BaseNode.save_data>`
+
     :param name: Name of node. Used in log or test.
     :param log_output: To enable output logging for this node.
     :store_output_as: Store output message in msg.ctx as specified key
@@ -107,6 +109,9 @@ class BaseNode:
             setattr(self, 'handle', self._log_handle)
 
     def fullpath(self):
+        """
+        Return the channel name and node name dot concatened.
+        """
         return "%s.%s" % (self.channel.name, self.name)
 
     async def handle(self, msg):

--- a/pypeman/persistence.py
+++ b/pypeman/persistence.py
@@ -16,10 +16,14 @@ SENTINEL = object()
 _backend = None
 
 async def get_backend(loop):
+    """
+    Return the configured backend instance.
+
+    :param loop: Asyncio loop to use. Passed backend instance.
+    """
     global _backend
-
     if not _backend:
-
+        # Load backend on first use
         if not settings.PERSISTENCE_BACKEND:
             raise Exception("Persistence backend not configured.")
 
@@ -27,20 +31,43 @@ async def get_backend(loop):
         loaded_module = importlib.import_module(module)
         _backend = getattr(loaded_module, class_)(loop=loop, **settings.PERSISTENCE_CONFIG)
 
+        await _backend.start()
+
     return _backend
 
 
 class MemoryBackend():
+    """
+    Memory persistence backend.
+    Only for testing purpose as this is not really persistent.
+    """
     def __init__(self, loop=None):
+        self.loop = loop
         self._data = defaultdict(dict)
 
     async def start(self):
+        """
+        Do nothing for this backend.
+        """
         pass
 
     async def store(self, namespace, key, value):
+        """ Store the value in a dict in memory
+
+        :param namespace: Namespace for dict.
+        :param key: Access key.
+        :param value: Value to save.
+        """
         self._data[namespace][key] = value
 
     async def get(self, namespace, key, default=SENTINEL):
+        """
+        Get the value from memory.
+
+        :param namespace: Namespace for dict.
+        :param key: Key to get.
+        :param default: Default value if key missing.
+        """
         if default is not SENTINEL:
             return self._data[namespace].get(key, default)
         else:
@@ -48,24 +75,29 @@ class MemoryBackend():
 
 
 class SqliteBackend():
+    """
+    Sqlite persistence backend. Store data in an sqlite database with
+    ACID garanties. Internally use a thread pool to execute database access.
+
+    :param path: Path of sqlite file.
+    :param thread_pool: If you want a specific thread_pool you can give one here.
+    :param loop: Loop used for the executor.
+    """
     def __init__(self, path, thread_pool=None, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self.loop = loop
-
-        if thread_pool is None:
-            self.executor = ThreadPoolExecutor(max_workers=1)
-        else:
-            self.executor = thread_pool
-
+        self.loop = loop or asyncio.get_event_loop()
+        self.executor = thread_pool or ThreadPoolExecutor(max_workers=1)
         self.path = path
 
     async def start(self):
+        """
+        Do nothing for this backend.
+        """
         pass
 
     def _sync_store(self, namespace, key, value):
         with SqliteDict(self.path, tablename=namespace) as pdict:
             pdict[key] = value
+            pdict.commit()
 
     def _sync_get(self, namespace, key, default):
         with SqliteDict(self.path, tablename=namespace) as pdict:
@@ -75,8 +107,21 @@ class SqliteBackend():
                 return pdict[key]
 
     async def store(self, namespace, key, value):
-        self.loop.run_in_executor(self.executor, self._sync_store, namespace, key, value)
+        """ Store the value in a dict saved in sqlite db.
+
+        :param namespace: Namespace table name.
+        :param key: Access key.
+        :param value: Value to save.
+        """
+        await self.loop.run_in_executor(self.executor, self._sync_store, namespace, key, value)
 
     async def get(self, namespace, key, default=SENTINEL):
-        return self.loop.run_in_executor(self.executor, self._sync_get, namespace, key, default)
+        """
+        Get the value from sqlite db.
+
+        :param namespace: Namespace table name.
+        :param key: Key to get.
+        :param default: Default value if key missing.
+        """
+        return await self.loop.run_in_executor(self.executor, self._sync_get, namespace, key, default)
 

--- a/pypeman/persistence.py
+++ b/pypeman/persistence.py
@@ -1,0 +1,82 @@
+"""
+This module contains all persistence related things.
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from collections import defaultdict
+import importlib
+
+from sqlitedict import SqliteDict
+
+from pypeman.conf import settings
+
+SENTINEL = object()
+
+_backend = None
+
+async def get_backend(loop):
+    global _backend
+
+    if not _backend:
+
+        if not settings.PERSISTENCE_BACKEND:
+            raise Exception("Persistence backend not configured.")
+
+        module, _, class_ = settings.PERSISTENCE_BACKEND.rpartition('.')
+        loaded_module = importlib.import_module(module)
+        _backend = getattr(loaded_module, class_)(loop=loop, **settings.PERSISTENCE_CONFIG)
+
+    return _backend
+
+
+class MemoryBackend():
+    def __init__(self, loop=None):
+        self._data = defaultdict(dict)
+
+    async def start(self):
+        pass
+
+    async def store(self, namespace, key, value):
+        self._data[namespace][key] = value
+
+    async def get(self, namespace, key, default=SENTINEL):
+        if default is not SENTINEL:
+            return self._data[namespace].get(key, default)
+        else:
+            return self._data[namespace][key]
+
+
+class SqliteBackend():
+    def __init__(self, path, thread_pool=None, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
+
+        if thread_pool is None:
+            self.executor = ThreadPoolExecutor(max_workers=1)
+        else:
+            self.executor = thread_pool
+
+        self.path = path
+
+    async def start(self):
+        pass
+
+    def _sync_store(self, namespace, key, value):
+        with SqliteDict(self.path, tablename=namespace) as pdict:
+            pdict[key] = value
+
+    def _sync_get(self, namespace, key, default):
+        with SqliteDict(self.path, tablename=namespace) as pdict:
+            if default is not SENTINEL:
+                return pdict.get(key, default)
+            else:
+                return pdict[key]
+
+    async def store(self, namespace, key, value):
+        self.loop.run_in_executor(self.executor, self._sync_store, namespace, key, value)
+
+    async def get(self, namespace, key, default=SENTINEL):
+        return self.loop.run_in_executor(self.executor, self._sync_get, namespace, key, default)
+

--- a/pypeman/tests/settings/test_settings_persistence.py
+++ b/pypeman/tests/settings/test_settings_persistence.py
@@ -1,0 +1,6 @@
+"""
+Persistence configuration
+"""
+
+PERSISTENCE_BACKEND = 'pypeman.persistence.MemoryBackend'
+PERSISTENCE_CONFIG = {}

--- a/pypeman/tests/settings/test_settings_persistence.py
+++ b/pypeman/tests/settings/test_settings_persistence.py
@@ -1,5 +1,5 @@
 """
-Persistence configuration
+Persistence configuration for sqlite
 """
 
 PERSISTENCE_BACKEND = 'pypeman.persistence.MemoryBackend'

--- a/pypeman/tests/settings/test_settings_sqlite_persist.py
+++ b/pypeman/tests/settings/test_settings_sqlite_persist.py
@@ -1,0 +1,6 @@
+"""
+Persistence configuration
+"""
+
+PERSISTENCE_BACKEND = 'pypeman.persistence.SqliteBackend'
+PERSISTENCE_CONFIG = {"path":'/tmp/to_be_removed_849827198746.sqlite'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ websockets
 jsonrpcserver
 jsonrpcclient[websockets]
 ipython
+sqlitedict

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url=URL,
 
     author='Jeremie Pardou',
-    author_email='jeremie.pardou@mhcomm.fr',
+    author_email='jeremie@jeremiez.net',
 
     license='Apache Software License',
     packages=['pypeman', 'pypeman.helpers', 'pypeman.contrib'],


### PR DESCRIPTION
Nodes use now persistent data between two pypeman executions to save things like "last execution time" to allow differential running on database for example.