### PR TITLE
allows to use remote admin via a reverse proxy.

### DIFF
--- a/pypeman/default_settings.py
+++ b/pypeman/default_settings.py
@@ -10,16 +10,17 @@ DEBUG_PARAMS = dict(
     slow_callback_duration=0.1
 )
 
-REMOTE_ADMIN_WEBSOCKET_CONFIG =  {
+REMOTE_ADMIN_WEBSOCKET_CONFIG = {
     'host': 'localhost',
     'port': '8091',
-    'ssl': None
+    'ssl': None,
+    'url': None, # must be set when behind a reverse proxy
 }
 
 REMOTE_ADMIN_WEB_CONFIG = {
     'host': 'localhost',
     'port': '8090',
-    'ssl': None
+    'ssl': None,
 }
 
 HTTP_ENDPOINT_CONFIG = ['0.0.0.0', '8080']

--- a/pypeman/remoteadmin.py
+++ b/pypeman/remoteadmin.py
@@ -41,7 +41,7 @@ class RemoteAdminServer():
     Expose json/rpc function to a client by a websocket.
     """
 
-    def __init__(self, loop=None, host='localhost', port='8091', ssl=None):
+    def __init__(self, loop=None, host='localhost', port='8091', ssl=None, url=None):
         self.host = host
         self.port = port
         self.ssl = ssl
@@ -431,7 +431,7 @@ class WebAdmin():
 
     async def handle_config(self, request):
         conf = settings.REMOTE_ADMIN_WEBSOCKET_CONFIG
-        server_url = "ws{is_secure}://{host}:{port}".format(
+        server_url = conf['url'] or "ws{is_secure}://{host}:{port}".format(
             is_secure='s' if conf['ssl'] else '',
             **conf
         )


### PR DESCRIPTION
The current remote interface is not suited to work behind a reverse proxy.

With these minimal changes it is possible to get remote admin coexisting on an existing webserver:

Three redirections are required (If interested I can post an example config for nginx)"

/prefix1/ to redirect to http(s)://pypemanhost:http_port
/prefix2/ to redirect to ws(s)://pypemanhost:ws_port
/configs.js to redirect to http(s)://pypemanhost:http_port/configs.js

With some more  changes the first two redirects should be sufficient. (Perhaps with an href of "../configs.js" ?