### PR TITLE
FileWatcher does no more silence all exceptions.

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -631,6 +631,8 @@ class FileWatcherChannel(BaseChannel):
                                 fut = ensure_future(self.handle(msg), loop=self.loop)
                                 fut.add_done_callback(self._handle_callback)
 
+        except: # TODO: might explicitely silence some special cases.
+            self.logger.exception("filewatcher problem")
         finally:
             if not self.status in (BaseChannel.STOPPING, BaseChannel.STOPPED,):
                 ensure_future(self.watch_for_file(), loop=self.loop)


### PR DESCRIPTION
file encoding issues due to a bad locale on a system were silently
ingored and not reported.

It might perhaps be helpful to silence some warnings, though at the moment I tend to
silence none of these warnings.

List of a few potential exceptions (there are probably much more):
- files that get created and then deleted/renamed
- file permission issues
- partially written files, that are truncated at a multibyte character in text mode
- file encoding issues of not in binary mode