### PR TITLE
Dvl/cust exception

### DIFF
--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -75,8 +75,9 @@ class HttpChannel(channels.BaseChannel):
         self.http_endpoint = endpoint
 
     async def start(self):
+        first_start = self._first_start
         await super().start()
-        if self._first_start:
+        if first_start:
             self.http_endpoint.add_route(self.method, self.url, self.handle_request)
 
     async def handle_request(self, request):

--- a/pypeman/errors.py
+++ b/pypeman/errors.py
@@ -1,0 +1,5 @@
+class PypemanError(Exception):
+    """ custom error """
+
+class PypemanConfigError(PypemanError):
+    """ custom error """

--- a/pypeman/msgstore.py
+++ b/pypeman/msgstore.py
@@ -6,6 +6,8 @@ from collections import OrderedDict
 
 from pypeman.message import Message
 
+from pypeman.errors import PypemanConfigError
+
 logger = logging.getLogger("pypeman.store")
 
 DATE_FORMAT = '%Y%m%d_%H%M'
@@ -173,6 +175,8 @@ class FileMessageStoreFactory(MessageStoreFactory):
     # TODO add an option to reguraly archive old file or delete them
     def __init__(self, path):
         super().__init__()
+        if path is None:
+            raise PypemanConfigError('file message store requires a path')
         self.base_path = path
 
     def get_store(self, store_id):


### PR DESCRIPTION
Adding this exception allows to easier understand / locate an error if a message store
has no proper path argument, but a None value
(can happen due to missing env vars / broken settings)

To see the difference try to run a project with a node with a message store with None as path
- once without this patch
- with this patch
