### PR TITLE
socket for http endpoint, REUSEPORT

### DIFF
--- a/pypeman/errors.py
+++ b/pypeman/errors.py
@@ -3,3 +3,6 @@ class PypemanError(Exception):
 
 class PypemanConfigError(PypemanError):
     """ custom error """
+
+class PypemanParamError(PypemanError):
+    """ custom error """

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -12,6 +12,7 @@ from pypeman import message
 from pypeman import nodes
 from pypeman import msgstore
 from pypeman import events
+from pypeman.errors import PypemanParamError
 from pypeman.tests.common import TestException, generate_msg
 
 class TestNode(nodes.BaseNode):
@@ -309,12 +310,27 @@ class ChannelsTests(unittest.TestCase):
                           BaseChannel.PROCESSING, BaseChannel.WAITING, BaseChannel.STOPPING, BaseChannel.STOPPED]
         self.assertEqual(state_sequence, valid_sequence, "Sequence state is not valid")
 
-    def test_http_channe(self):
+    def test_http_channel(self):
         """ Whether HTTPChannel is working"""
 
         # TODO it's just for regression now. Make better test
-        end = endpoints.HTTPEndpoint(loop=self.loop)
-        chan = channels.HttpChannel(name="httpchan", endpoint=end, loop=self.loop)
+        dflt_endp = endpoints.HTTPEndpoint(loop=self.loop)
+        self.assertEqual(dflt_endp.url, 'localhost:8080')
+        chan1 = channels.HttpChannel(name="httpchan1", endpoint=dflt_endp, loop=self.loop)
+
+        hp_endp = endpoints.HTTPEndpoint(loop=self.loop, address='localhost', port=8081)
+        self.assertEqual(hp_endp.url, 'localhost:8081')
+        chan2 = channels.HttpChannel(name="httpchan2", endpoint=hp_endp, loop=self.loop)
+        
+        url_endp = endpoints.HTTPEndpoint(loop=self.loop, address='localhost', port=8081, url='0.0.0.0:8082')
+        self.assertEqual(url_endp.url, '0.0.0.0:8082')
+        chan3 = channels.HttpChannel(name="httpchan3", endpoint=url_endp, loop=self.loop)
+
+        def mk_bp_endp():
+            return endpoints.HTTPEndpoint(loop=self.loop, url='0.0.0.0:8082', sock='place_holder')
+
+        self.assertRaises(PypemanParamError, mk_bp_endp)
+        
 
     def test_ftp_channel(self):
         """ Whether FTPWatcherChannel is working"""

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -315,19 +315,26 @@ class ChannelsTests(unittest.TestCase):
 
         # TODO it's just for regression now. Make better test
         dflt_endp = endpoints.HTTPEndpoint(loop=self.loop)
-        self.assertEqual(dflt_endp.url, 'localhost:8080')
+        dflt_endp.make_socket()
+        self.assertEqual(dflt_endp.sock, 'localhost:8080')
         chan1 = channels.HttpChannel(name="httpchan1", endpoint=dflt_endp, loop=self.loop)
 
         hp_endp = endpoints.HTTPEndpoint(loop=self.loop, address='localhost', port=8081)
-        self.assertEqual(hp_endp.url, 'localhost:8081')
+        hp_endp.make_socket()
+        self.assertEqual(hp_endp.sock, 'localhost:8081')
         chan2 = channels.HttpChannel(name="httpchan2", endpoint=hp_endp, loop=self.loop)
         
-        url_endp = endpoints.HTTPEndpoint(loop=self.loop, address='localhost', port=8081, url='0.0.0.0:8082')
-        self.assertEqual(url_endp.url, '0.0.0.0:8082')
-        chan3 = channels.HttpChannel(name="httpchan3", endpoint=url_endp, loop=self.loop)
+        def mk_url_endp():
+            url_endp = endpoints.HTTPEndpoint(loop=self.loop, address='localhost', port=8081, host='0.0.0.0:8082')
+            url_endp.make_socket()
+
+        self.assertRaises(PypemanParamError, mk_url_endp)
+
 
         def mk_bp_endp():
-            return endpoints.HTTPEndpoint(loop=self.loop, url='0.0.0.0:8082', sock='place_holder')
+            endp = endpoints.HTTPEndpoint(loop=self.loop, host='0.0.0.0:8082', sock='place_holder')
+            endp.make_socket()
+            return endp
 
         self.assertRaises(PypemanParamError, mk_bp_endp)
         

--- a/pypeman/tests/test_imports.py
+++ b/pypeman/tests/test_imports.py
@@ -1,0 +1,14 @@
+import unittest
+
+class ImportTests(unittest.TestCase):
+    def test_ftp_import(self):
+        import pypeman.contrib.ftp
+    def test_hl7_import(self):
+        import pypeman.contrib.hl7
+    def test_http_import(self):
+        import pypeman.contrib.http
+    def test_time_import(self):
+        import pypeman.contrib.time
+    def test_xml_import(self):
+        import pypeman.contrib.xml
+


### PR DESCRIPTION
socket reuseport option uses a linux feature. It allows two processes to listen on the same port.
With this feature we can start two pypemEn with the same config.
Will be used for soft restart without losing any incoming connection. 