### PR TITLE
switch over to pytest.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+python_files = test_*.py *_tests.py tests_*.py
+testpaths = pypeman
+norecursedirs = pypeman/client
+addopts = --junit-xml=nosetests.xml  --continue-on-collection-errors 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ aiohttp
 aiocron
 coverage
 codecov
+pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,8 @@ description-file = README.md
 tests=pypeman/tests
 ignore-files=tests\.py
 
+[aliases]
+test=pytest
+
+[tool:pytest]
+testpaths = pypeman

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
         'time': ["aiocron"],
         'all': ["hl7", "xmltodict", "aiocron"]
     },
-    tests_require=['nose', 'nose-cover3'],
+    setup_requires=['pytest-runner'],
+    tests_require=[
+        'pytest', 'pytest-cov', 'pytest-asyncio'
+        ],
     include_package_data=True,
 )


### PR DESCRIPTION
Main reason is to allow us in future tests to use pytest-asyncio
https://github.com/pytest-dev/pytest-asyncio

This might resolve some issues in tests. The current test fails for
example on servers where port 8091 is aleady being used as a listening
port seems to be hardcoded.

pytest-asyncio however would allow us to use the 'unused_tcp_port' fixture in order
to provide the test runner with an unused tcp port.

pytest-asyncio has also a 'event_loop' fixture, which might help during test development.