### PR TITLE
Reuse socket option for MLLP endpoint

### DIFF
--- a/pypeman/contrib/hl7.py
+++ b/pypeman/contrib/hl7.py
@@ -118,7 +118,6 @@ class MLLPEndpoint(endpoints.SocketEndpoint):
             srv = await self.loop.create_server(
                 protocol_factory=lambda: MLLPProtocol(self.handler, loop=self.loop),
                 sock=self.sock_obj,
-                reuse_port=self.reuse_port,
             )
             print("MLLP server started at http://{}:{}".format(self.address, self.port))
             return srv

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -1,7 +1,6 @@
 import asyncio
 import ssl
 import warnings
-import socket
 import logging
 
 import aiohttp
@@ -14,7 +13,7 @@ from pypeman.errors import PypemanParamError
 logger = logging.getLogger(__name__)
 
 
-class HTTPEndpoint(endpoints.BaseEndpoint):
+class HTTPEndpoint(endpoints.SocketEndpoint):
     """
     Endpoint to receive HTTP connection from outside.
 
@@ -38,59 +37,32 @@ class HTTPEndpoint(endpoints.BaseEndpoint):
                 or socket-string ("unix:/sojet/file/path")
                 or bound socket object
         """
-        super().__init__()
+
         self.http_args = http_args or {}
         self.ssl_context = self.http_args.pop('ssl_context', None)
-        self.loop = loop or asyncio.get_event_loop()
-        self.reuse_port = reuse_port
         self._app = None
  
         address = address or adress
         if address or port:
-            warnings.warn("HTTPEndpoint 'address', 'adress' and 'port' params are deprecated. Replace it by 'host' or 'sock'", 
-                DeprecationWarning)
+            warnings.warn("HTTPEndpoint 'address', 'adress' and 'port' params are deprecated. "
+                "Replace it by 'host' or 'sock'", DeprecationWarning)
             if host or sock:
-                raise PypemanParamError("Obsolete params ('adress', 'address', 'port') can not be mixed with new params ('host', 'sock')") 
-            sock = sock or host or ((address if address else '')+ ':' + str(port if port else ''))
+                raise PypemanParamError("Obsolete params ('adress', 'address', 'port') "
+                    "can not be mixed with new params ('host', 'sock')") 
+            sock = sock or host or ((address if address else '') + ':' + str(port if port else ''))
  
         if host and sock:
             raise PypemanParamError("There can only be one (parameter host or sock)")
-        self.sock = sock or host or ''
-
-
-    def make_socket(self):
-        """
-            make and bind socket if string object is passed
-        """
-        sock = self.sock
-        if not isinstance(sock, str):
-            self.sock_obj = sock
-            if self.reuse_port:
-                SO_REUSEPORT = 15
-                self.sock_obj.setsockopt(socket.SOL_SOCKET, SO_REUSEPORT, 1)
-            return
-
-        if not sock.startswith('unix:'):
-            if ':' not in sock:
-                sock += ':'
-            host, port = sock.split(":")
-            host = host or 'localhost'
-            port = int(port or 8080)
-            self.sock = host + ':' + str(port)
-            sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            if self.reuse_port:
-                SO_REUSEPORT = 15
-                sock_obj.setsockopt(socket.SOL_SOCKET, SO_REUSEPORT, 1)
-            sock_obj.bind((host, port))
-        else:
-            path = sock.split(":", 1)[1]
-            sock_obj = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            if self.reuse_port:
-                SO_REUSEPORT = 15
-                sock_obj.setsockopt(socket.SOL_SOCKET, SO_REUSEPORT, 1)
-            sock_obj.bind(path)
-        self.sock_obj = sock_obj
-        
+        sock = sock or host or ''
+        if isinstance(sock, str):
+            if not sock.startswith('unix:'):
+                if ':' not in sock:
+                    sock += ':'
+                host, port = sock.split(":")
+                host = host or 'localhost'
+                port = port or '8080'
+                sock = host + ':' + port
+        super().__init__(loop, sock, reuse_port)
 
     def add_route(self, *args, **kwargs):
         if self._app is None:

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -49,20 +49,13 @@ class HTTPEndpoint(endpoints.SocketEndpoint):
             if host or sock:
                 raise PypemanParamError("Obsolete params ('adress', 'address', 'port') "
                     "can not be mixed with new params ('host', 'sock')") 
-            sock = sock or host or ((address if address else '') + ':' + str(port if port else ''))
+            sock = (address if address else '') + ':' + str(port if port else '')
  
         if host and sock:
             raise PypemanParamError("There can only be one (parameter host or sock)")
         sock = sock or host or ''
-        if isinstance(sock, str):
-            if not sock.startswith('unix:'):
-                if ':' not in sock:
-                    sock += ':'
-                host, port = sock.split(":")
-                host = host or 'localhost'
-                port = port or '8080'
-                sock = host + ':' + port
-        super().__init__(loop, sock, reuse_port)
+
+        super().__init__(loop=loop, sock=sock, reuse_port=reuse_port)
 
     def add_route(self, *args, **kwargs):
         if self._app is None:

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -25,7 +25,7 @@ class HTTPEndpoint(endpoints.SocketEndpoint):
             http_args=None,
             host=None,
             sock=None,
-            reuse_port=False,
+            reuse_port=None,
             ):
         """
             :param http_args: dict to pass as **kwargs** to aiohttp.Application for example for
@@ -76,7 +76,8 @@ class HTTPEndpoint(endpoints.SocketEndpoint):
             srv = await self.loop.create_server(
                 protocol_factory=self._app.make_handler(),
                 sock=self.sock_obj,
-                ssl=self.ssl_context
+                ssl=self.ssl_context,
+                reuse_port=self.reuse_port,
             )
             message = "Server started at %r" % self.sock
             print(message)

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -70,7 +70,6 @@ class HTTPEndpoint(endpoints.SocketEndpoint):
                 protocol_factory=self._app.make_handler(),
                 sock=self.sock_obj,
                 ssl=self.ssl_context,
-                reuse_port=self.reuse_port,
             )
             message = "Server started at %r" % self.sock
             print(message)

--- a/pypeman/endpoints.py
+++ b/pypeman/endpoints.py
@@ -21,6 +21,7 @@ class SocketEndpoint(BaseEndpoint):
         """
             :param reuse_port: bool if true then the listening port specified in the url parameter) 
                 will be shared with other processes on same port
+                no effect with bound socket object
             :param sock: string 'host:port'
                 or socket-string ("unix:/sojet/file/path")
                 or bound socket object
@@ -60,6 +61,9 @@ class SocketEndpoint(BaseEndpoint):
             else:
                 bind_param = sock.split(":", 1)[1]
                 sock_obj = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            if self.reuse_port:
+                SO_REUSEPORT = 15
+                sock_obj.setsockopt(socket.SOL_SOCKET, SO_REUSEPORT, 1)
             sock_obj.bind(bind_param)
         else:
             sock_obj = sock

--- a/pypeman/endpoints.py
+++ b/pypeman/endpoints.py
@@ -1,4 +1,9 @@
 import asyncio
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
 
 all = []
 
@@ -10,11 +15,55 @@ class BaseEndpoint:
     async def start(self):
         pass
 
+
+class SocketEndpoint(BaseEndpoint):
+    def __init__(self, loop=None, sock=None, reuse_port=False):
+        """
+            :param reuse_port: bool if true then the listening port specified in the url parameter) 
+                will be shared with other processes on same port
+            :param sock: string 'host:port'
+                or socket-string ("unix:/sojet/file/path")
+                or bound socket object
+        """
+        super().__init__()
+        self.loop = loop or asyncio.get_event_loop()
+        self.reuse_port = reuse_port
+        self.sock = sock
+
+    def make_socket(self):
+        """
+            make and bind socket if string object is passed
+        """
+        sock = self.sock
+        if isinstance(sock, str):
+            if not sock.startswith('unix:'):
+                try:
+                    host, port = sock.split(":")
+                    port = int(port)
+                    if not host:
+                        raise
+                    bind_param = (host, port)
+                except:
+                    logger.exception('error on sock params in socket endpoint')
+                    raise
+                sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            else:
+                bind_param = sock.split(":", 1)[1]
+                sock_obj = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock_obj.bind(bind_param)
+        else:
+            sock_obj = sock
+
+        if self.reuse_port:
+            SO_REUSEPORT = 15
+            sock_obj.setsockopt(socket.SOL_SOCKET, SO_REUSEPORT, 1)
+
+        self.sock_obj = sock_obj
+
+
 from pypeman.helpers import lazyload
 
 wrap = lazyload.Wrapper(__name__)
 
 wrap.add_lazy('pypeman.contrib.http', 'HTTPEndpoint', ['aiohttp'])
 wrap.add_lazy('pypeman.contrib.hl7', 'MLLPEndpoint', ['hl7'])
-
-

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -316,7 +316,7 @@ class ChannelsTests(unittest.TestCase):
     def test_http_channel(self, mock_sock):
         """ Whether HTTPChannel is working"""
         tests = [
-            dict(out_params={'sock':'localhost:8080'}),
+            dict(out_params={'sock':'127.0.0.1:8080'}),
             dict(
                 in_params={'address':'localhost', 'port':8081}, 
                 out_params={'sock':'localhost:8081'},
@@ -342,8 +342,8 @@ class ChannelsTests(unittest.TestCase):
             ),
             dict(
                 in_params={'port':8081},
-                out_params={'sock':'localhost:8081'},
-                comment="dflt addr localhost",
+                out_params={'sock':'127.0.0.1:8081'},
+                comment="dflt addr 127.0.0.1",
             ),
             dict(
                 in_params={'host':'0.0.0.0:8082', 'reuse_port':True},

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -312,10 +312,9 @@ class ChannelsTests(unittest.TestCase):
         self.assertEqual(state_sequence, valid_sequence, "Sequence state is not valid")
 
 
-    @mock.patch('pypeman.contrib.http.socket')
+    @mock.patch('socket.socket')
     def test_http_channel(self, mock_sock):
         """ Whether HTTPChannel is working"""
-
         tests = [
             dict(out_params={'sock':'localhost:8080'}),
             dict(
@@ -353,8 +352,7 @@ class ChannelsTests(unittest.TestCase):
         ]
 
         fake_socket = mock.MagicMock()
-        mock_sock.socket.return_value = fake_socket
-
+        mock_sock.return_value = fake_socket
         for test in tests:
             in_params = test.get('in_params',{})
             out_params = test.get('out_params',{})
@@ -389,7 +387,7 @@ class ChannelsTests(unittest.TestCase):
             endp = mk_endp()
 
             if isinstance(endp.sock, str):
-                assert mock_sock.socket.called
+                assert mock_sock.called
                 sock_params = out_params.get('sock', 'localhost:8080')
                 sock_host, sock_port = sock_params.split(":")
                 assert fake_socket.bind.called_with(sock_host, sock_port)


### PR DESCRIPTION
Socket endpoint and reuse_port from unix

In my test, os use the first pypeman each time ...
how test socket in unitest ?