### PR TITLE
freeze version of jsonrpcclient req <=2.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ begins
 daemonlite
 websockets
 jsonrpcserver
-jsonrpcclient[websockets]
+jsonrpcclient[websockets]<=2.5.2
+
 requests # For jsonrpcclient
 ipython
 sqlitedict


### PR DESCRIPTION
The current version failed.
Did not try to find the most recent working version.