### PR TITLE
freeze max version of jsonrpcserver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 begins
 daemonlite
 websockets
-jsonrpcserver
+jsonrpcserver<4
 jsonrpcclient[websockets]<=2.5.2
 
 requests # For jsonrpcclient


### PR DESCRIPTION
unfortunately another incompatible update of jsonrpcserver.
Freeze version for the moment to avoid fails of the rest of pypeman