### PR TITLE
allow to project module from pypeman settings

### DIFF
--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -44,17 +44,18 @@ from pypeman import remoteadmin  # noqa
 
 def load_project():
     settings.init_settings()
+    project_module = settings.PROJECT_MODULE
     try:
-        importlib.import_module('project')
+        importlib.import_module(project_module)
     except ImportError as exc:
         msg = str(exc)
         if 'No module' not in msg:
-            print("IMPORT ERROR project")
+            print("IMPORT ERROR %s" % project_module)
             raise
-        if 'project' not in msg:
-            print("IMPORT ERROR project")
+        if project_module not in msg:
+            print("IMPORT ERROR %s" % project_module)
             raise
-        print("Missing 'project.py' file !")
+        print("Missing '%s' module !" % project_module)
         sys.exit(-1)
     except Exception:
         traceback.print_exc()

--- a/pypeman/default_settings.py
+++ b/pypeman/default_settings.py
@@ -6,6 +6,8 @@ This settings should be redifined.
 DEBUG = False    # bool. can be set by env var PYPEMAN_DEBUG (0|1|true|false) or pypeman cmd args
 TESTING = False  # bool. can be set by env var PYPEMAN_TESTING (0|1|true|false) pypeman cmd args
 
+PROJECT_MODULE = "project"  # name of module containing the project
+
 DEBUG_PARAMS = dict(
     slow_callback_duration=0.1
 )


### PR DESCRIPTION
this allows to specify the name of the module, that contains the project
in pypeman settings.

Can come in handy for testing, sub projects, etc.