### PR TITLE
Dvl/klausf/add aio compat

### DIFF
--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -27,7 +27,12 @@ from DaemonLite import DaemonLite
 CURRENT_DIR = os.getcwd()  # noqa: E402
 sys.path.insert(0, CURRENT_DIR)  # noqa: E402
 
+# To be imported prior to any other pypeman imports
+import pypeman.helpers.aio_compat
+pypeman.helpers.aio_compat.patch()  # noqa: E402
+
 import pypeman
+
 from pypeman import channels
 from pypeman import endpoints
 from pypeman import nodes

--- a/pypeman/helpers/aio_compat.py
+++ b/pypeman/helpers/aio_compat.py
@@ -1,0 +1,35 @@
+import asyncio
+import sys
+
+# code copieds from https://github.com/feenes/mytb v0.0.13
+#  file: mytb/aio/compat.py
+
+# Not tested for pre 3.4 versions
+assert sys.version_info >= (3, 4)
+
+patched = []  # keeps track of what has been patched
+
+
+def patch():
+    """
+    patches pre 3.7 asyncios with some hacky but 'compatible' back ports
+    """
+
+    if not hasattr(asyncio, "run"):
+        # asyncio.run function has been added to asyncio in
+        # Python 3.7 on a provisional basis.
+        #
+
+        def run(coro):
+            loop = asyncio.get_event_loop()
+            loop.create_task(coro)
+            loop.run_forever()
+
+        asyncio.run = run
+        patched.append("asyncio.run")
+
+    if not hasattr(asyncio, "all_tasks"):
+        # from python 3.7 on asyncio.all_tasks replaces asyncio.Task.all_tasks,
+        # which will be removed in Python 3.9
+        asyncio.all_tasks = asyncio.Task.all_tasks
+        patched.append("asyncio.all_tasks")


### PR DESCRIPTION
add a helper allowing to write some python 3.7 compatible asyncio statements with older python versions.

Please merge this only after https://github.com/mhcomm/pypeman/pull/115
All intersting diffs are in  commits https://github.com/mhcomm/pypeman/pull/117/commits/c1c66df164e6900a471324de23324f9fe01a16d7

The other changes are just the changes of PR #115 


If https://github.com/mhcomm/pypeman/issues/116 is accepted we could add the .travis and tox changes in this MR,  as this will prove, that the changes really work with 3.5, 3.6 and 3.7
