### PR TITLE
Dvl/klaus/bug #55

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -12,7 +12,6 @@ from pypeman import message, msgstore, events
 from pypeman.helpers.sleeper import Sleeper
 
 
-
 logger = logging.getLogger(__name__)
 
 # List all channel registered

--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -9,6 +9,9 @@ import warnings
 from asyncio import ensure_future
 
 from pypeman import message, msgstore, events
+from pypeman.helpers.sleeper import Sleeper
+
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +68,7 @@ class BaseChannel:
         self._node_map = {}
         self._status = BaseChannel.STOPPED
         self.processed_msgs = 0
+        self.interruptable_sleeper = Sleeper(loop)  # for interruptable sleeps
 
         if name:
             self.name = name
@@ -163,13 +167,17 @@ class BaseChannel:
 
     async def stop(self):
         """
-        Stop the channel. Called when pypeman shutdown.
-
+        Stop the channel.
+        Called when
+        - pypeman shuts down.
+        - a channel is stopped (e.g. via the admin interface)
         """
         self.status = BaseChannel.STOPPING
         # Verify that all messages are processed
         with (await self.lock):
             self.status = BaseChannel.STOPPED
+        # stop all pending sleeps
+        await self.interruptable_sleeper.cancel_all()
 
     def _reset_test(self):
         """ Enable test mode and reset node data.
@@ -612,8 +620,10 @@ class FileWatcherChannel(BaseChannel):
             pass
 
     async def watch_for_file(self):
-        # TODO cancel sleep on channel stopping
-        await asyncio.sleep(self.interval, loop=self.loop)
+        self.logger.warning("Will sleep")
+        await self.interruptable_sleeper.sleep(self.interval)
+        # await asyncio.sleep(self.interval, loop=self.loop)
+        self.logger.warning("sleep done")
         try:
             if os.path.exists(self.basedir):
                 listfile = os.listdir(self.basedir)
@@ -646,6 +656,8 @@ class FileWatcherChannel(BaseChannel):
         finally:
             if self.status not in (BaseChannel.STOPPING, BaseChannel.STOPPED,):
                 ensure_future(self.watch_for_file(), loop=self.loop)
+            else:
+                logger.warning("Won't watch anymore")
 
 
 from pypeman.helpers import lazyload  # noqa: E402

--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -47,7 +47,6 @@ from pypeman.helpers.reloader import reloader_opt
 if len(sys.argv) == 1:
     sys.argv.append('-h')
 
-<<<<<<< 540cbeaa6d0020bc28ef1f6c6daf56033cc830f2
 
 async def sig_handler_coro(loop, signal, ctx):
     """
@@ -112,7 +111,6 @@ def main(debug_asyncio=False, profile=False, cli=False, remote_admin=False):
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGHUP, signal_handler)
-
 
     if debug_asyncio:
         loop.slow_callback_duration = settings.DEBUG_PARAMS['slow_callback_duration']

--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -44,10 +44,10 @@ from pypeman.helpers.reloader import reloader_opt
 # TODO: remove below if statement asap. This is a workaround for a bug in begins
 # TODO: which provokes an exception when calling pypeman without parameters.
 # TODO: more info at https://github.com/aliles/begins/issues/48
-
 if len(sys.argv) == 1:
     sys.argv.append('-h')
 
+<<<<<<< 540cbeaa6d0020bc28ef1f6c6daf56033cc830f2
 
 async def sig_handler_coro(loop, signal, ctx):
     """
@@ -101,6 +101,18 @@ def main(debug_asyncio=False, profile=False, cli=False, remote_admin=False):
 
     logger = logging.getLogger(__name__)
     loop = asyncio.get_event_loop()
+
+    ctx = dict(
+        logger=logger,
+        loop=loop,
+        )
+
+    signal_handler = partial(sig_handler_func, ctx=ctx)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGHUP, signal_handler)
+
 
     if debug_asyncio:
         loop.slow_callback_duration = settings.DEBUG_PARAMS['slow_callback_duration']

--- a/pypeman/helpers/sleeper.py
+++ b/pypeman/helpers/sleeper.py
@@ -1,5 +1,6 @@
 import asyncio
 
+
 class Sleeper:
     """
     Group sleep calls allowing instant cancellation of all

--- a/pypeman/helpers/sleeper.py
+++ b/pypeman/helpers/sleeper.py
@@ -41,6 +41,7 @@ class Sleeper:
         Coroutine cancelling tasks
         """
         cancelled = self.cancel_all_helper()
-        await asyncio.wait(self.tasks)
+        if self.tasks:
+            await asyncio.wait(self.tasks)
         self.tasks -= cancelled
         return len(cancelled)

--- a/pypeman/helpers/sleeper.py
+++ b/pypeman/helpers/sleeper.py
@@ -1,0 +1,38 @@
+import asyncio
+
+class Sleeper:
+    """
+    Group sleep calls allowing instant cancellation of all
+
+    found at: https://stackoverflow.com/questions/37209864/interrupt-all-asyncio-sleep-currently-executing
+    """
+
+    def __init__(self, loop):
+        self.loop = loop
+        self.tasks = set()
+
+    async def sleep(self, delay, result=None):
+        coro = asyncio.sleep(delay, result=result, loop=self.loop)
+        task = asyncio.ensure_future(coro)
+        self.tasks.add(task)
+        try:
+            return await task
+        except asyncio.CancelledError:
+            return result
+        finally:
+            self.tasks.remove(task)
+
+    def cancel_all_helper(self):
+        "Cancel all pending sleep tasks"
+        cancelled = set()
+        for task in self.tasks:
+            if task.cancel():
+                cancelled.add(task)
+        return cancelled
+
+    async def cancel_all(self):
+        "Coroutine cancelling tasks"
+        cancelled = self.cancel_all_helper()
+        await asyncio.wait(self.tasks)
+        self.tasks -= cancelled
+        return len(cancelled)

--- a/pypeman/helpers/sleeper.py
+++ b/pypeman/helpers/sleeper.py
@@ -3,7 +3,7 @@ import asyncio
 
 class Sleeper:
     """
-    Group sleep calls allowing instant cancellation of all
+    Group of sleep calls allowing instant cancellation of all
 
     found at: https://stackoverflow.com/questions/37209864/interrupt-all-asyncio-sleep-currently-executing
     """
@@ -13,6 +13,9 @@ class Sleeper:
         self.tasks = set()
 
     async def sleep(self, delay, result=None):
+        """
+        a sleep function, that can be interrupted
+        """
         coro = asyncio.sleep(delay, result=result, loop=self.loop)
         task = asyncio.ensure_future(coro)
         self.tasks.add(task)
@@ -24,7 +27,9 @@ class Sleeper:
             self.tasks.remove(task)
 
     def cancel_all_helper(self):
-        "Cancel all pending sleep tasks"
+        """
+        Cancel all pending sleep tasks
+        """
         cancelled = set()
         for task in self.tasks:
             if task.cancel():
@@ -32,7 +37,9 @@ class Sleeper:
         return cancelled
 
     async def cancel_all(self):
-        "Coroutine cancelling tasks"
+        """
+        Coroutine cancelling tasks
+        """
         cancelled = self.cancel_all_helper()
         await asyncio.wait(self.tasks)
         self.tasks -= cancelled

--- a/pypeman/tests/tests_bin.py
+++ b/pypeman/tests/tests_bin.py
@@ -84,6 +84,6 @@ class BinPypemanTestCase(unittest.TestCase):
         """ subcommand test is working """
 
         cmd = self.cmd + ['test']
-        self.run_pypeman(cmd, cwd=os.path.join('pypeman', 'tests', 'test_app_testing'))
+        self.run_pypeman(cmd, cwd=os.path.join(os.path.dirname(CWD), 'test_app_testing'))
 
 # test_suite =  BinPypemanTestCase


### PR DESCRIPTION
This should address bug https://github.com/mhcomm/pypeman/issues/55

The implementation is done by creating an interrruptible  Sleeper class.

At the moment each channel will have it's own sleeper class, such, that each channel can be terminated individually.

In order to use the interruptable sleeps
one should use

`await channel.interruptable_sleeper.sleep(interval)`

instead of 
`await asyncio.sleep(interval)`