### PR TITLE
test with newer python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install tox
 script:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        # must get rid of begins annotations to make 3.8 work
+        # 'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
+# py38 still failing
 envlist=py35
         py36
+        py37
+        py38
 
 [testenv:py35]
 deps =
@@ -15,6 +18,30 @@ commands=
 passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
 
 [testenv:py36]
+deps =
+    nose
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements_test.txt
+    flake8
+commands=
+    python -m flake8 pypeman
+    pytest --cov=pypeman --cov-config=.coveragerc
+    codecov
+passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+
+[testenv:py37]
+deps =
+    nose
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements_test.txt
+    flake8
+commands=
+    python -m flake8 pypeman
+    pytest --cov=pypeman --cov-config=.coveragerc
+    codecov
+passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+
+[testenv:py38]
 deps =
     nose
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
as 3.5 is the oldest version still being mentioned in the python docs
we should ensure pypeman still runs with the newer versions.

This PR adds python 3.7 (3.8 cannot be added until https://github.com/mhcomm/pypeman/issues/121 is done)

This PR addresses thus https://github.com/mhcomm/pypeman/issues/116