### PR TITLE
fix #135 pypeman pytest returns now the correct exit code

### DIFF
--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -402,7 +402,7 @@ def pytest(ctx, args):
     if not args:
         args = ["tests.py"]
     rslt = pytest.main(list(args))
-    return rslt  # required to return the error code of pytest
+    sys.exit(rslt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes #135 

exit code 0 if all tests pass
other exit codes otherwise (refer to the pytest documentation)

