### PR TITLE
#126 CombineCtx Node + tests

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -15,9 +15,9 @@ from pypeman.helpers.sleeper import Sleeper
 logger = logging.getLogger(__name__)
 
 # List all channel registered
-all = []
+all_channels = []
 
-_channels_names = set()
+_channel_names = set()
 
 
 class Dropped(Exception):
@@ -62,7 +62,7 @@ class BaseChannel:
 
         self.uuid = uuid.uuid4()
 
-        all.append(self)
+        all_channels.append(self)
         self._nodes = []
         self._node_map = {}
         self._status = BaseChannel.STOPPED
@@ -73,7 +73,7 @@ class BaseChannel:
             self.name = name
         else:
             warnings.warn("Channels without names are deprecated", DeprecationWarning)
-            self.name = self.__class__.__name__ + "_" + str(len(all))
+            self.name = self.__class__.__name__ + "_" + str(len(all_channels))
 
         self.parent = None
         if parent_channel:
@@ -91,13 +91,13 @@ class BaseChannel:
         else:
             self.parent_uids = None
 
-        if self.name in _channels_names:
+        if self.name in _channel_names:
             raise NameError(
                 "Duplicate channel name %r . "
                 "Channel names must be unique !" % self.name
             )
 
-        _channels_names.add(self.name)
+        _channel_names.add(self.name)
 
         if loop is None:
             self.loop = asyncio.get_event_loop()
@@ -471,6 +471,17 @@ class BaseChannel:
 
     def __str__(self):
         return "<chan: %s>" % self.name
+
+
+def reset_pypeman_channels():
+    """
+    clears book keeping of all channels
+
+    Can be useful for unit testing.
+    """
+    logger.info("clearing all_channels and _channel-names.")
+    all_channels.clear()
+    _channel_names.clear()
 
 
 class SubChannel(BaseChannel):

--- a/pypeman/commands.py
+++ b/pypeman/commands.py
@@ -50,7 +50,7 @@ async def sig_handler_coro(loop, signal, ctx):
     """
     logger = ctx["logger"]
     logger.debug("signal handler coro called for signal %s", signal)
-    for channel in channels.all:
+    for channel in channels.all_channels:
         logger.debug("stop channel %s", channel.name)
         await channel.stop()
     # sleep for a grace period of 3 seconds. Might be able to remove lateron
@@ -114,7 +114,7 @@ def main(debug_asyncio=False, profile=False, cli=False, remote_admin=False):
         warnings.simplefilter('default')
 
     # Start channels
-    for chan in channels.all:
+    for chan in channels.all_channels:
         loop.run_until_complete(chan.start())
 
     # add signal handlers
@@ -131,7 +131,7 @@ def main(debug_asyncio=False, profile=False, cli=False, remote_admin=False):
         loop.add_signal_handler(sig, partial(sig_handler_func, loop, sig, ctx))
 
     # And endpoints
-    for end in endpoints.all:
+    for end in endpoints.all_channels:
         loop.run_until_complete(end.start())
 
     # At the moment mixing the asyncio and ipython
@@ -177,7 +177,7 @@ def main(debug_asyncio=False, profile=False, cli=False, remote_admin=False):
 
     print("End started tasks...")
 
-    for chan in channels.all:
+    for chan in channels.all_channels:
         loop.run_until_complete(chan.stop())
 
     pending = asyncio.Task.all_tasks()
@@ -280,7 +280,7 @@ def show_ascii_graph(title=None):
     """
     if title:
         print(title)
-    for channel in channels.all:
+    for channel in channels.all_channels:
         if not channel.parent:
             print(channel.__class__.__name__)
             channel.graph()
@@ -316,11 +316,11 @@ def graph(dot):
         print("digraph testgraph{")
 
         # Handle channel node shape
-        for channel in channels.all:
+        for channel in channels.all_channels:
             print('{node[shape=box]; "%s"; }' % channel.name)
 
         # Draw each graph
-        for channel in channels.all:
+        for channel in channels.all_channels:
             if not channel.parent:
                 channel.graph_dot()
 

--- a/pypeman/contrib/ctx.py
+++ b/pypeman/contrib/ctx.py
@@ -1,0 +1,63 @@
+"""
+Additional Nodes for working with the context
+"""
+
+import pypeman.nodes as nodes
+
+from pypeman.nodes import NodeException
+
+
+class CombineCtx(nodes.BaseNode):
+    """
+    creates payload dict with combination of different contexts
+    """
+
+    def __init__(self, ctx_names, meta_from=None, flatten=False,  *args, **kwargs):
+        """
+            param ctx_names: list of context names to save or dict with mapping
+                   of context name to payload keys
+            param: flatten: if true all ctx payloads (must be dicts) will be combined
+                    in one dict
+            param: meta_from: specifies which meta the resulting message should have
+        """
+        super().__init__(*args, **kwargs)
+        if not isinstance(ctx_names, dict):
+            if flatten:
+                ctx_dst = len(ctx_names) * [None]
+            else:
+                ctx_dst = ctx_names
+            ctx_names = dict(zip(ctx_names, ctx_dst))
+        self.ctx_names = ctx_names
+        if len(ctx_names) < 2:
+            raise NodeException("must have at least two contexts for combining")
+        if meta_from is None:
+            meta_from = next(iter(ctx_names.keys()))
+        self.meta_from = meta_from
+
+    def process(self, msg):
+        payload = {}
+        ch_logger = self.channel.logger
+        ch_logger.debug(
+            "combine ctx_names = %s / meta from %r",
+            repr(self.ctx_names),
+            self.meta_from,
+            )
+        # TODO: can we just copy the meta if the payload changed?
+        # TODO: If not, then rmv meta_from param and create new meta
+        msg.meta = msg.ctx[self.meta_from]['meta']
+
+        for ctx_name, dst in self.ctx_names.items():
+            ch_logger.debug("combine ctx = %s -> %s", ctx_name, dst)
+            if dst is None:
+                ctx_payload = msg.ctx[ctx_name]['payload']
+                ch_logger.debug(
+                    "upd payload with ctx payload of %s ( %s )",
+                    ctx_name, repr(ctx_payload))
+                payload.update(ctx_payload)
+            else:
+                payload[dst] = msg.ctx[ctx_name]['payload']
+            ch_logger.debug("combine payload = %s", repr(payload))
+
+        msg.payload = payload
+
+        return msg

--- a/pypeman/endpoints.py
+++ b/pypeman/endpoints.py
@@ -5,13 +5,22 @@ import socket
 logger = logging.getLogger(__name__)
 
 
-all = []
+all_endpoints = []
+
+
+def reset_pypeman_endpoints():
+    """
+    clears book keeping of all endpoints
+
+    Can be useful for unit testing.
+    """
+    all_endpoints.clear()
 
 
 class BaseEndpoint:
 
     def __init__(self):
-        all.append(self)
+        all_endpoints.append(self)
 
     async def start(self):
         pass

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -790,6 +790,7 @@ from pypeman.helpers import lazyload  # noqa: E402
 
 wrap = lazyload.Wrapper(__name__)
 
+wrap.add_lazy('pypeman.contrib.ctx', "CombineCtx", [])
 wrap.add_lazy('pypeman.contrib.xml', "XMLToPython", ["xmltodict"])
 wrap.add_lazy('pypeman.contrib.xml', "PythonToXML", ["xmltodict"])
 wrap.add_lazy('pypeman.contrib.hl7', "HL7ToPython", ["hl7"])
@@ -798,4 +799,5 @@ wrap.add_lazy('pypeman.contrib.http', "HttpRequest", ["aiohttp"])
 wrap.add_lazy('pypeman.contrib.http', "RequestNode", ["aiohttp"])
 wrap.add_lazy('pypeman.contrib.ftp', "FTPFileWriter", [])
 wrap.add_lazy('pypeman.contrib.ftp', "FTPFileReader", [])
+wrap.add_lazy('pypeman.contrib.ftp', "FTPFileDeleter", [])
 wrap.add_lazy('pypeman.contrib.ftp', "FTPFileDeleter", [])

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 loop = asyncio.get_event_loop()
 
 # All declared nodes registered here
-all = []  # TODO: might consider renaming. all is a default python function
+all_nodes = []
+node_by_name = {}
 
 # Can be redefined
 default_thread_pool = ThreadPoolExecutor(max_workers=3)
@@ -99,13 +100,14 @@ class BaseNode:
         cls = self.__class__
         self.channel = None
 
-        all.append(self)
+        all_nodes.append(self)
 
-        name = name or cls.__name__ + "_" + str(len(all))
+        name = name or cls.__name__ + "_" + str(len(all_nodes))
         if name in cls._used_names:
             raise NodeException(
                 "can't create Node with name %s. It exists already" % name)
         cls._used_names.add(name)
+        node_by_name[name] = self
         self.name = name
 
         self.store_output_as = kwargs.pop('store_output_as', None)
@@ -778,8 +780,13 @@ class Email(ThreadNode):
 
 
 def reset_pypeman_nodes():
-    logger.info("clearing all and _used-names for nodes.")
-    all.clear()
+    """
+    clears book keeping of all channels
+
+    Can be useful for unit testing.
+    """
+    logger.info("clearing all_nodes and BaseNode._used-names.")
+    all_nodes.clear()
     BaseNode._used_names.clear()
 
 # Contrib nodes

--- a/pypeman/remoteadmin.py
+++ b/pypeman/remoteadmin.py
@@ -51,9 +51,9 @@ class RemoteAdminServer():
 
     def get_channel(self, name):
         """
-        return channel by is name.all
+        return channel by is name.all_channels
         """
-        for chan in channels.all:
+        for chan in channels.all_channels:
             if chan.name == name:
                 return chan
         return None
@@ -106,7 +106,7 @@ class RemoteAdminServer():
         Return a list of available channels.
         """
         chans = []
-        for chan in channels.all:
+        for chan in channels.all_channels:
             if not chan.parent:
                 chan_dict = chan.to_dict()
                 chan_dict['subchannels'] = chan.subchannels()

--- a/pypeman/test.py
+++ b/pypeman/test.py
@@ -28,7 +28,7 @@ class PypeTestCase(TestCase):
         This class is necessary as asyncio and pypeman have
         some global persistent objects like
         asyncio default loop
-        pypeman.nodes.all / pypeman.channles.all, ...
+        pypeman.nodes.all_nodes / pypeman.channels.all_channels, ...
 
         Anybody using unittest.TestCase based tests for a pypeman
         project should use this class instead.
@@ -53,7 +53,7 @@ class PypeTestCase(TestCase):
         asyncio.set_event_loop(None)
 
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             chan.loop = cls.loop
             cls.loop.run_until_complete(chan.start())
             chan._reset_test()
@@ -64,7 +64,7 @@ class PypeTestCase(TestCase):
         Replace current loop by a new one to avoid side effect on
         next test.
         """
-        for chan in channels.all:
+        for chan in channels.all_channels:
             cls.loop.run_until_complete(chan.stop())
 
         pending = asyncio.Task.all_tasks(loop=cls.loop)
@@ -74,7 +74,7 @@ class PypeTestCase(TestCase):
         cls.loop = asyncio.new_event_loop()
 
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             chan.loop = cls.loop
             cls.loop.run_until_complete(chan.start())
             chan._reset_test()
@@ -84,7 +84,7 @@ class PypeTestCase(TestCase):
         super().tearDownClass()
 
         # Stop channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             cls.loop.run_until_complete(chan.stop())
 
         cls.finish_all_tasks()
@@ -118,7 +118,7 @@ class PypeTestCase(TestCase):
         :return: Channel instance corresponding to `name`
             or None if channel not found.
         """
-        for chan in channels.all:
+        for chan in channels.all_channels:
             if chan.name == name:
                 chan._reset_test()
                 return chan

--- a/pypeman/tests/common.py
+++ b/pypeman/tests/common.py
@@ -63,7 +63,7 @@ def generate_msg(timestamp=None, message_content=default_message_content,
     m.payload = message_content
 
     if message_meta is None:
-        m.meta = default_message_meta
+        m.meta = dict(default_message_meta)
     else:
         m.meta = message_meta
 

--- a/pypeman/tests/pytest_helpers.py
+++ b/pypeman/tests/pytest_helpers.py
@@ -1,0 +1,23 @@
+"""
+Helpers / fixtures for pytest
+"""
+
+import pytest
+
+import pypeman.channels
+import pypeman.endpoints
+import pypeman.nodes
+
+
+@pytest.fixture(scope="function")
+def clear_graph():
+    n_nodes = len(pypeman.nodes.all_nodes)
+    n_channels = len(pypeman.channels.all_channels)
+    n_endpoints = len(pypeman.endpoints.all_endpoints)
+    pypeman.nodes.reset_pypeman_nodes()
+    pypeman.channels.reset_pypeman_channels()
+    pypeman.endpoints.reset_pypeman_endpoints()
+    yield n_nodes, n_channels, n_endpoints
+    pypeman.nodes.reset_pypeman_nodes()
+    pypeman.channels.reset_pypeman_channels()
+    pypeman.endpoints.reset_pypeman_endpoints()

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -39,7 +39,7 @@ class ChannelsTests(TestCase):
 
     def start_channels(self):
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             self.loop.run_until_complete(chan.start())
 
     def setUp(self):
@@ -52,7 +52,7 @@ class ChannelsTests(TestCase):
         asyncio.set_event_loop(None)
 
         # Avoid calling already tested channels
-        channels.all.clear()
+        channels.all_channels.clear()
 
     def tearDown(self):
         super().tearDown()
@@ -458,7 +458,7 @@ class ChannelsTests(TestCase):
             fake_ftp.download_file.assert_called_once_with("testdir/file3")
 
             # To avoid auto launch of ftp watch
-            channels.all.remove(chan)
+            channels.all_channels.remove(chan)
 
             del chan
 

--- a/pypeman/tests/test_ctx_nodes.py
+++ b/pypeman/tests/test_ctx_nodes.py
@@ -36,7 +36,6 @@ def mk_msgs_w_ctx(*ctx_ids):
     return msg, ctx_msgs
 
 
-#    def __init__(self, ctx_names, meta_from=None, flatten=False,  *args, **kwargs):
 @pytest.mark.usefixtures("clear_graph")
 def test_combine_ctx_not_two_names(event_loop):
     with pytest.raises(NodeException):

--- a/pypeman/tests/test_ctx_nodes.py
+++ b/pypeman/tests/test_ctx_nodes.py
@@ -1,0 +1,91 @@
+"""
+tests for pypeman.contrib.ctx
+"""
+
+import asyncio
+
+import pytest
+
+from pypeman.contrib.ctx import CombineCtx
+from pypeman.nodes import NodeException
+from pypeman.tests.pytest_helpers import clear_graph  # noqa: F401
+
+from pypeman.tests.common import generate_msg
+# TODO: might refactor to another file?
+from pypeman.tests.test_nodes import FakeChannel
+
+
+def mk_msgs_w_ctx(*ctx_ids):
+    """
+    helper to create a msg with a few contexts
+    """
+    msg = generate_msg(
+        message_content="test",
+        message_meta=dict(entry1="meta1"),
+        )
+    ctx_msgs = []
+    for ctx_id in ctx_ids:
+        meta = dict(entry1="meta_%s" % ctx_id)
+        ctx_msg = generate_msg(
+            message_content={"val_%s" % ctx_id: "data_%s" % ctx_id},
+            message_meta=meta,
+            )
+        msg.add_context(ctx_id, ctx_msg)
+        ctx_msgs.append(ctx_msg)
+
+    return msg, ctx_msgs
+
+
+#    def __init__(self, ctx_names, meta_from=None, flatten=False,  *args, **kwargs):
+@pytest.mark.usefixtures("clear_graph")
+def test_combine_ctx_not_two_names(event_loop):
+    with pytest.raises(NodeException):
+        CombineCtx([], name="ctx1")
+    with pytest.raises(NodeException):
+        CombineCtx(["a"], name="ctx2")
+
+
+@pytest.mark.usefixtures("clear_graph")
+def test_combine_ctx_2_names(event_loop):
+    loop = event_loop
+    asyncio.set_event_loop(loop)
+    # nut == Node Under Test
+    nut = CombineCtx(["a", "b"], name="ctx1")
+    nut.channel = FakeChannel(loop)
+    msg, ctx_msgs = mk_msgs_w_ctx("a", "b")
+
+    rslt = loop.run_until_complete(nut.handle(msg))
+    assert rslt.payload["a"] == ctx_msgs[0].payload
+    assert rslt.payload["b"] == ctx_msgs[1].payload
+    assert rslt.meta == ctx_msgs[0].meta
+
+
+@pytest.mark.usefixtures("clear_graph")
+def test_combine_ctx_2_names_w_meta(event_loop):
+    loop = event_loop
+    asyncio.set_event_loop(loop)
+    # nut == Node Under Test
+    nut = CombineCtx(["a", "b"], meta_from="b", name="ctx1")
+    nut.channel = FakeChannel(loop)
+    msg, ctx_msgs = mk_msgs_w_ctx("a", "b")
+
+    rslt = loop.run_until_complete(nut.handle(msg))
+    assert rslt.payload["a"] == ctx_msgs[0].payload
+    assert rslt.payload["b"] == ctx_msgs[1].payload
+    assert rslt.meta == ctx_msgs[1].meta
+
+
+@pytest.mark.usefixtures("clear_graph")
+def test_combine_ctx_2_names_flat(event_loop):
+    loop = event_loop
+    asyncio.set_event_loop(loop)
+    # nut == Node Under Test
+    nut = CombineCtx(["a", "b"], name="ctx1", flatten=True)
+    nut.channel = FakeChannel(loop)
+    msg, ctx_msgs = mk_msgs_w_ctx("a", "b")
+
+    rslt = loop.run_until_complete(nut.handle(msg))
+    exp_payload = dict(ctx_msgs[0].payload)
+    exp_payload.update(ctx_msgs[1].payload)
+    assert rslt.payload == exp_payload
+    assert rslt.meta == ctx_msgs[0].meta

--- a/pypeman/tests/test_msgstore.py
+++ b/pypeman/tests/test_msgstore.py
@@ -49,7 +49,7 @@ class MsgstoreTests(TestCase):
 
     def start_channels(self):
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             self.loop.run_until_complete(chan.start())
 
     def setUp(self):
@@ -62,7 +62,7 @@ class MsgstoreTests(TestCase):
         asyncio.set_event_loop(None)
 
         # Avoid calling already tested channels
-        channels.all.clear()
+        channels.all_channels.clear()
 
     def tearDown(self):
         super().tearDown()

--- a/pypeman/tests/test_remoteadmin.py
+++ b/pypeman/tests/test_remoteadmin.py
@@ -35,7 +35,7 @@ class RemoteAdminTests(TestCase):
 
     def start_channels(self):
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             self.loop.run_until_complete(chan.start())
 
     def setUp(self):
@@ -48,7 +48,7 @@ class RemoteAdminTests(TestCase):
         asyncio.set_event_loop(None)
 
         # Avoid calling already tested channels
-        channels.all.clear()
+        channels.all_channels.clear()
 
     def tearDown(self):
         super().tearDown()

--- a/pypeman/tests/test_testing.py
+++ b/pypeman/tests/test_testing.py
@@ -22,7 +22,7 @@ class TestingTests(TestCase):
 
     def start_channels(self):
         # Start channels
-        for chan in channels.all:
+        for chan in channels.all_channels:
             self.loop.run_until_complete(chan.start())
 
     def setUp(self):
@@ -35,7 +35,7 @@ class TestingTests(TestCase):
         asyncio.set_event_loop(None)
 
         # Avoid calling already tested channels
-        channels.all.clear()
+        channels.all_channels.clear()
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
Will address #126

CombineCtx node has been added with 4 unit tests

Additional changes:
- `all` is a reserved python word, therefore some renaming:
- - `pypeman.channels.all` -> `pypeman.channels.all_channels`
- - `pypeman.nodes.all` -> `pypeman.nodes.all_channels`
- - `pypeman.endpoints.all` -> `pypeman.endpoints.all_channels`
- add function (for testing) `reset_pypeman_channels`
- add function (for testing) `reset_pypeman_endpoints`
- add a pytest fixture for resetting pypeman graph for each test
- minor fix in pypeman.tests.common (create copy of a dict)