### PR TITLE
with -> async with for newer aiohttp

### DIFF
--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -5,6 +5,6 @@ recommonmark
 sphinx_rtd_theme
 hl7
 xmltodict
-aiohttp
+aiohttp>3.0
 aiocron
 

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -220,7 +220,8 @@ class HttpRequest(nodes.BaseNode):
         data = None
         if method in ['put', 'post']:
             data = msg.payload
-        with aiohttp.ClientSession(connector=conn) as session:
+        # async with is required for newer versions of aiohttp
+        async with aiohttp.ClientSession(connector=conn) as session:
             resp = await session.request(
                     method=method,
                     url=url,

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 tox
 hl7
 xmltodict
-aiohttp
+aiohttp>3.0
 aiocron
 coverage
 codecov

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "click",
         "daemonlite",
         "websockets<7",
-        "aiohttp",
+        "aiohttp>3.0",
         "jsonrpcclient[websockets]<=2.5.2",
         "jsonrpcserver<4",
         "sqlitedict",


### PR DESCRIPTION
aiohttp requires now "async with" instead of "with" for
the context manager.

code + aiohttp requirements updated