### PR TITLE
rmv very noisy combine log

### DIFF
--- a/pypeman/contrib/ctx.py
+++ b/pypeman/contrib/ctx.py
@@ -56,7 +56,6 @@ class CombineCtx(nodes.BaseNode):
                 payload.update(ctx_payload)
             else:
                 payload[dst] = msg.ctx[ctx_name]['payload']
-            ch_logger.debug("combine payload = %s", repr(payload))
 
         msg.payload = payload
 


### PR DESCRIPTION
this log logs the entire payload. (all payloads of the contexts
that were combined)

This is not such a good idea.

The log is now removed. Something like that can be added during
development if required.