### PR TITLE
fix speed response (add wait_subchans param)

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -57,6 +57,9 @@ class BaseChannel:
     :param message_store_factory:     You can specify a message store (see below) at channel
         initialisation if you want to save all processed message. Use
         `message_store_factory` argument with  an instance of wanted message store factory.
+
+    :param wait_subchans: Boolean, if set to True, channels will wait for suchannel ends for sending,
+    speed response and process a new message
     """
     STARTING, WAITING, PROCESSING, STOPPING, STOPPED = range(5)
     STATE_NAMES = ['STARTING', 'WAITING', 'PROCESSING', 'STOPPING', 'STOPPED']

--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -61,7 +61,8 @@ class BaseChannel:
     STARTING, WAITING, PROCESSING, STOPPING, STOPPED = range(5)
     STATE_NAMES = ['STARTING', 'WAITING', 'PROCESSING', 'STOPPING', 'STOPPED']
 
-    def __init__(self, name=None, parent_channel=None, loop=None, message_store_factory=None):
+    def __init__(self, name=None, parent_channel=None, loop=None, message_store_factory=None,
+                 wait_subchans=False):
 
         self.uuid = uuid.uuid4()
 
@@ -76,6 +77,7 @@ class BaseChannel:
         self.drop_nodes = None
         self.reject_nodes = None
         self.final_nodes = None
+        self.wait_subchans = wait_subchans
 
         if name:
             self.name = name
@@ -262,7 +264,8 @@ class BaseChannel:
 
         s = SubChannel(
             name=name, parent_channel=self,
-            message_store_factory=message_store_factory, loop=self.loop)
+            message_store_factory=message_store_factory, loop=self.loop,
+            wait_subchans=self.wait_subchans)
         self._nodes.append(s)
         return s
 
@@ -278,7 +281,8 @@ class BaseChannel:
 
         s = ConditionSubChannel(
             condition=condition, name=name, parent_channel=self,
-            message_store_factory=message_store_factory, loop=self.loop)
+            message_store_factory=message_store_factory, loop=self.loop,
+            wait_subchans=self.wait_subchans)
         self._nodes.append(s)
         return s
 
@@ -305,7 +309,8 @@ class BaseChannel:
             names = [None] * len(conditions)
 
         c = Case(*conditions, names=names, parent_channel=self,
-                 message_store_factory=message_store_factory, loop=self.loop)
+                 message_store_factory=message_store_factory, loop=self.loop,
+                 wait_subchans=self.wait_subchans)
         self._nodes.append(c)
         return [chan for cond, chan in c.cases]
 
@@ -377,14 +382,17 @@ class BaseChannel:
                     await self.final_nodes[0].handle(msg.copy())
                 try:
                     if self.sub_chan_tasks:
-                        # Launch and wait for sub chans handle()
-                        await asyncio.gather(*self.sub_chan_tasks)
+                        # Launch sub chans handle()
+                        subchantasks = asyncio.gather(*self.sub_chan_tasks)
+                        if self.wait_subchans:
+                            await subchantasks
                 finally:
                     if self.sub_chan_endnodes:
                         # Launch and wait for sub chans callbacks
                         subchan_endnodes_fut = asyncio.gather(*self.sub_chan_endnodes)
                         subchan_endnodes_fut.add_done_callback(self._reset_sub_chan_endnodes)
-                        await subchan_endnodes_fut
+                        if self.wait_subchans:
+                            await subchan_endnodes_fut
 
     async def subhandle(self, msg):
         """ Overload this method only if you know what you are doing. Called by ``handle`` method.
@@ -720,7 +728,8 @@ class ConditionSubChannel(BaseChannel):
 class Case():
     """ Case node internally used for `.case()` BaseChannel method. Don't use it.
     """
-    def __init__(self, *args, names=None, parent_channel=None, message_store_factory=None, loop=None):
+    def __init__(self, *args, names=None, parent_channel=None, message_store_factory=None, loop=None,
+                 wait_subchans=False):
         self.next_node = None
         self.cases = []
 
@@ -735,7 +744,7 @@ class Case():
         for cond, name in zip(args, names):
             b = BaseChannel(name=name, parent_channel=parent_channel,
                             message_store_factory=message_store_factory,
-                            loop=self.loop)
+                            loop=self.loop, wait_subchans=wait_subchans)
             self.cases.append((cond, b))
 
     def _reset_test(self):

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -555,7 +555,7 @@ class ChannelsTests(TestCase):
         """
             Whether endnodes are working correctly in complex channels and subchannels
         """
-        chan1 = BaseChannel(name="test_subchannel_clbk", loop=self.loop)
+        chan1 = BaseChannel(name="test_subchannel_clbk", loop=self.loop, wait_subchans=True)
         n1 = TstNode(name="n1")
         chan1.add(n1)
         subchan1 = chan1.fork(name="sub1")
@@ -723,7 +723,7 @@ class ChannelsTests(TestCase):
     def test_sub_channel(self):
         """ Whether Sub Channel is working """
 
-        chan = BaseChannel(name="test_channel3", loop=self.loop)
+        chan = BaseChannel(name="test_channel3", loop=self.loop, wait_subchans=True)
         n1 = TstNode(name="main")
         n2 = TstNode(name="sub")
         n3 = TstNode(name="sub1")
@@ -755,7 +755,7 @@ class ChannelsTests(TestCase):
     def test_sub_channel_with_exception(self):
         """ Whether Sub Channel exception handling is working """
 
-        chan = BaseChannel(name="test_channel4", loop=self.loop)
+        chan = BaseChannel(name="test_channel4", loop=self.loop, wait_subchans=True)
         n1 = TstNode(name="main")
         n2 = TstNode(name="sub")
         n3 = ExceptNode(name="exc")


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/mhcomm/pypeman/pull/176

Add booloean param `wait_subchans` to BaseChannel
Default = False. If set to True, Channel will wait for subchannels 
(before procesing new messages or returning their status (like "DROPPED" for HttpChannel) 