### PR TITLE
manual Bump css-what from 2.1.0 to 6.1.0

### DIFF
--- a/pypeman/client/package-lock.json
+++ b/pypeman/client/package-lock.json
@@ -2790,7 +2790,7 @@
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "integrity": "sha512-HtdI8TqiYjVrBI0C2VLF8fwphIa49EaHPVo64hrX+QHCPBtjp2FW1g4+jNeC6v7bBSr2z7v2USnQ6GU+VPOzgQ==",
       "dev": true
     },
     "cssesc": {


### PR DESCRIPTION
manual apply of dependabot PR #181

Bumps [css-what](https://github.com/fb55/css-what) from 2.1.0 to 6.1.0.
- [Release notes](https://github.com/fb55/css-what/releases)
- [Commits](fb55/css-what@v2.1.0...v6.1.0)

---
updated-dependencies:
- dependency-name: css-what dependency-type: indirect ...