### PR TITLE
tox ini needs now ',' instead of ' '

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands=
     python -m flake8 pypeman
     pytest --cov=pypeman --cov-config=.coveragerc
     codecov
-passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+passenv=PYPEMAN_*,CODECOV_TOKEN,TRAVIS,TRAVIS_*
 
 [testenv:py38]
 deps =
@@ -26,7 +26,7 @@ commands=
     python -m flake8 pypeman
     pytest --cov=pypeman --cov-config=.coveragerc
     codecov
-passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+passenv=PYPEMAN_*,CODECOV_TOKEN,TRAVIS,TRAVIS_*
 
 [testenv:py39]
 deps =
@@ -38,7 +38,7 @@ commands=
     python -m flake8 pypeman
     pytest --cov=pypeman --cov-config=.coveragerc
     codecov
-passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+passenv=PYPEMAN_*,CODECOV_TOKEN,TRAVIS,TRAVIS_*
 
 [testenv:py310]
 deps =
@@ -50,4 +50,4 @@ commands=
     python -m flake8 pypeman
     pytest --cov=pypeman --cov-config=.coveragerc
     codecov
-passenv=PYPEMAN_* CODECOV_TOKEN TRAVIS TRAVIS_*
+passenv=PYPEMAN_*,CODECOV_TOKEN,TRAVIS,TRAVIS_*


### PR DESCRIPTION
perhaps older versions were more tolerant.
now `passenv` requires comma separated values