### PR TITLE
MsgFuncNode and FuncNode

### DIFF
--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -905,7 +905,8 @@ class MsgFuncNode(BaseNode):
     and modifies it.
 
     The given function can be async or not.
-    The name for the node will automatically be using the function's name.
+    The name for the node will automatically be using the function's name if no
+    explicit value is specified.
 
         def do_something(msg):
             msg.meta ...
@@ -935,7 +936,8 @@ class FuncNode(BaseNode):
     payload and returns a (potentially identical) payload.
 
     The given function can be async or not.
-    The name for the node will automatically be using the function's name.
+    The name for the node will automatically be using the function's name if no
+    explicit value is specified.
 
         def do_something(payload):
             return payload + 1

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -899,6 +899,67 @@ class YielderNode(BaseNode):
         return generator(msg)
 
 
+class MsgFuncNode(BaseNode):
+    """
+    Make a node from a simple function/coroutine that takes the message
+    and modifies it.
+
+    The given function can be async or not.
+    The name for the node will automatically be using the function's name.
+
+        def do_something(msg):
+            msg.meta ...
+
+        MsgFuncNode(do_something)
+
+    See also `FuncNode` to work purely with the payload.
+    """
+
+    def __init__(self, fn, *, name: str = "", **kwargs):
+        if not name and fn.__name__ != "<lambda>":
+            name = self.__class__.__name__ + "_" + fn.__name__
+        super().__init__(name=name, **kwargs)
+        self.fn = fn
+
+    async def process(self, msg):
+        if asyncio.iscoroutinefunction(self.fn):
+            await self.fn(msg)
+        else:
+            self.fn(msg)
+        return msg
+
+
+class FuncNode(BaseNode):
+    """
+    Make a node from a simple function/coroutine that takes the message's
+    payload and returns a (potentially identical) payload.
+
+    The given function can be async or not.
+    The name for the node will automatically be using the function's name.
+
+        def do_something(payload):
+            return payload + 1
+
+        FuncNode(do_something)
+
+    See also `MsgFuncNode` to get the whole message.
+    """
+
+    def __init__(self, fn, *, name: str = "", **kwargs):
+        if not name and fn.__name__ != "<lambda>":
+            name = self.__class__.__name__ + "_" + fn.__name__
+        super().__init__(name=name, **kwargs)
+        self.fn = fn
+
+    async def process(self, msg):
+        msg.payload = (
+            await self.fn(msg.payload)
+            if asyncio.iscoroutinefunction(self.fn)
+            else self.fn(msg.payload)
+        )
+        return msg
+
+
 def reset_pypeman_nodes():
     """
     clears book keeping of all channels


### PR DESCRIPTION
This PR proposes 2 new nodes: `MsgFuncNode` and `FuncNode`.

It aims at cutting on boilerplate code involved when the operation performed by a node is reducible to only its `process` method.

```py
def _to_zendesk_event(parsed_json):
    kind = parsed_json['kind']
    if kind == "newticket":
        return NewTicketEvent(...)
    ...

chan.add(
    nodes.JsonToPython(),
    nodes.FuncNode(_to_zendesk_event),
    nodes.Log(),
)
```