### PR TITLE
add auto retry

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -136,8 +136,6 @@ class BaseChannel:
             msgstore.NullMessageStoreFactory,
         )
         self.message_store = self.message_store_factory.get_store(self.name)
-        logger.critical(conf.SETTINGS_IMPORTED)
-        logger.critical(conf.settings.RETRY_STORE_PATH)
         if conf.SETTINGS_IMPORTED:
             retry_store_path = conf.settings.RETRY_STORE_PATH
         else:
@@ -496,6 +494,9 @@ class BaseChannel:
                 the channel's start. You could set it to "_initial", the message will be processed
                 from the start but will bypass init_nodes
                 Defaults to None.
+            call_endnodes (bool, default=True): Flag to indicate if endnodes have to be called
+                or not
+            set_state (bool, default=True): Flag to indicate if the final message state have to be set or not
         """
         retry_exc_catched = None
         try:
@@ -572,6 +573,15 @@ class BaseChannel:
                 raise retry_exc_catched
 
     async def _get_base_msg_from_child(self, msg):
+        """
+        Get a message in the message store from one of its child
+
+        Args:
+            msg (message.Message): The child message
+
+        Returns:
+            message.Message: The base/parent message
+        """
         base_msg_data = await self.message_store.get(msg.store_id)
         base_msg = base_msg_data["message"]
         base_msg.store_id = msg.store_id
@@ -585,6 +595,9 @@ class BaseChannel:
         Args:
             msg (message.Message): Message to inject
             start_nodename (str): Node name where inject the message
+            call_endnodes (bool, default=True): Flag to indicate if endnodes have to be called
+                or not
+            set_state (bool, default=True): Flag to indicate if the final message state have to be set or not
         """
         logger.debug(f"{self.short_name} Inject {msg} in {start_nodename}")
 

--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -9,6 +9,8 @@ import warnings
 
 from pathlib import Path
 
+from pypeman import exceptions
+from pypeman import conf
 from pypeman import message, msgstore, events
 from pypeman.exceptions import EndChanProcess
 from pypeman.exceptions import Dropped
@@ -16,6 +18,7 @@ from pypeman.exceptions import Rejected
 from pypeman.exceptions import ChannelStopped
 from pypeman.helpers.itertools import flatten
 from pypeman.helpers.sleeper import Sleeper
+from pypeman.retry import RetryFileMsgStore
 
 
 logger = logging.getLogger(__name__)
@@ -59,8 +62,8 @@ class BaseChannel:
     :param wait_subchans: Boolean, if set to True, channels will wait for suchannel ends for sending,
     speed response and process a new message
     """
-    STARTING, WAITING, PROCESSING, STOPPING, STOPPED = range(5)
-    STATE_NAMES = ['STARTING', 'WAITING', 'PROCESSING', 'STOPPING', 'STOPPED']
+    STARTING, WAITING, PROCESSING, STOPPING, STOPPED, PAUSED = range(6)
+    STATE_NAMES = ['STARTING', 'WAITING', 'PROCESSING', 'STOPPING', 'STOPPED', 'PAUSED']
 
     def __init__(self, name=None, parent_channel=None, loop=None, message_store_factory=None,
                  wait_subchans=False, verbose_name=None):
@@ -128,8 +131,28 @@ class BaseChannel:
         self.next_node = None
 
         self.message_store_factory = message_store_factory or msgstore.NullMessageStoreFactory()
-
+        self.has_message_store = not isinstance(
+            self.message_store_factory,
+            msgstore.NullMessageStoreFactory,
+        )
         self.message_store = self.message_store_factory.get_store(self.name)
+        logger.critical(conf.SETTINGS_IMPORTED)
+        logger.critical(conf.settings.RETRY_STORE_PATH)
+        if conf.SETTINGS_IMPORTED:
+            retry_store_path = conf.settings.RETRY_STORE_PATH
+        else:
+            logger.warning(
+                "Caution, settings not imported before chan init"
+            )
+            retry_store_path = None
+        if retry_store_path is not None:
+            self.retry_store = RetryFileMsgStore(
+                path=retry_store_path,
+                store_id=self.name,
+                channel=self,
+            )
+        else:
+            self.retry_store = None
 
         self._first_start = True
 
@@ -190,6 +213,8 @@ class BaseChannel:
         await self.message_store.start()
         self.status = BaseChannel.WAITING
         self.logger.info("Channel %s started", str(self))
+        if self.retry_store:
+            await self.retry_store.start()
 
     def init_node_graph(self):
         if self._nodes:
@@ -214,6 +239,8 @@ class BaseChannel:
         # stop all pending sleeps
         await self.interruptable_sleeper.cancel_all()
         self.logger.info("Channel %s stopped", str(self))
+        if self.retry_store:
+            await self.retry_store.stop()
 
     def _reset_test(self):
         """ Enable test mode and reset node data.
@@ -239,6 +266,8 @@ class BaseChannel:
         if self.fail_nodes:
             for node in self.fail_nodes:
                 node._reset_test()
+        if self.retry_store:
+            self.retry_store._reset_test()
 
     def add(self, *args):
         """
@@ -311,7 +340,6 @@ class BaseChannel:
 
         :return: The forked channel
         """
-
         s = SubChannel(
             name=name, parent_channel=self,
             message_store_factory=message_store_factory, loop=self.loop,
@@ -393,7 +421,7 @@ class BaseChannel:
                 start_node = self.init_nodes[0]
             idx_start_node = self.init_nodes.index(start_node)
             nodes = self.init_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=True)
         return msg
 
     async def _call_join_nodes(self, msg, start_nodename=None):
@@ -406,7 +434,7 @@ class BaseChannel:
                 start_node = self.join_nodes[0]
             idx_start_node = self.join_nodes.index(start_node)
             nodes = self.join_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=True)
 
     async def _call_drop_nodes(self, msg, start_nodename=None):
         if self.drop_nodes:
@@ -418,7 +446,7 @@ class BaseChannel:
                 start_node = self.drop_nodes[0]
             idx_start_node = self.drop_nodes.index(start_node)
             nodes = self.drop_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=False)
 
     async def _call_reject_nodes(self, msg, start_nodename=None):
         if self.reject_nodes:
@@ -430,7 +458,7 @@ class BaseChannel:
                 start_node = self.reject_nodes[0]
             idx_start_node = self.reject_nodes.index(start_node)
             nodes = self.reject_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=False)
 
     async def _call_fail_nodes(self, msg, start_nodename=None):
         if self.fail_nodes:
@@ -442,7 +470,7 @@ class BaseChannel:
                 start_node = self.fail_nodes[0]
             idx_start_node = self.fail_nodes.index(start_node)
             nodes = self.fail_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=False)
 
     async def _call_final_nodes(self, msg, start_nodename=None):
         if self.final_nodes:
@@ -454,9 +482,9 @@ class BaseChannel:
                 start_node = self.final_nodes[0]
             idx_start_node = self.final_nodes.index(start_node)
             nodes = self.final_nodes[idx_start_node:]
-            msg = await self._process_nodes(nodes=nodes, msg=msg.copy())
+            msg = await self._process_nodes(nodes=nodes, msg=msg.copy(), add_sub_state=False)
 
-    async def _call_base_handling(self, msg, start_nodename=None):
+    async def _call_base_handling(self, msg, start_nodename=None, call_endnodes=True, set_state=True):
         """
         Process message from the given node
             start_nodename must refer to a "classic" node, not init or end node
@@ -469,22 +497,25 @@ class BaseChannel:
                 from the start but will bypass init_nodes
                 Defaults to None.
         """
+        retry_exc_catched = None
         try:
             if not start_nodename:
                 msg = await self._call_init_nodes(msg=msg)
             result = await self.subhandle(msg.copy(), start_nodename=start_nodename)
-            await self.message_store.change_message_state(msg.store_id, message.Message.PROCESSED)
             msg.chan_rslt = result
-            if not self._has_callback():
+            if not self._has_callback() and call_endnodes:
                 await self._call_join_nodes(msg=result)
             return result
         except Dropped as exc:
             self.logger.info("%s DROP msg %s", str(self), str(msg))
             msg.chan_exc = exc
             msg.chan_exc_traceback = traceback.format_exc()
-            await self.message_store.change_message_state(msg.store_id, message.Message.PROCESSED)
-            if not self._has_callback():
-                await self._call_drop_nodes(msg=msg)
+            if not self._has_callback() and call_endnodes:
+                try:
+                    await self._call_drop_nodes(msg=msg)
+                except exceptions.RetryException as retry_exc:
+                    self.logger.info("%s CATCH RETRY in drop nodes for msg %s", str(self), str(msg))
+                    retry_exc_catched = retry_exc
             if self.raise_dropped:
                 raise
             return msg
@@ -492,25 +523,37 @@ class BaseChannel:
             self.logger.info("%s REJECT msg %s", str(self), str(msg))
             msg.chan_exc = exc
             msg.chan_exc_traceback = traceback.format_exc()
-            await self.message_store.change_message_state(msg.store_id, message.Message.REJECTED)
             await self.message_store.add_message_meta_infos(msg.store_id, "err_msg", str(exc))
-            if not self._has_callback():
-                await self._call_reject_nodes(msg=msg)
+            if not self._has_callback() and call_endnodes:
+                try:
+                    await self._call_reject_nodes(msg=msg)
+                except exceptions.RetryException as retry_exc:
+                    self.logger.info("%s CATCH RETRY in reject nodes for msg %s", str(self), str(msg))
+                    retry_exc_catched = retry_exc
             raise
+        except (exceptions.RetryException, exceptions.PausedChanException) as exc:
+            self.logger.info("%s CATCH RETRY for msg %s", str(self), str(msg))
+            retry_exc_catched = exc
+            await self.message_store.change_message_state(msg.store_id, message.Message.WAIT_RETRY)
+            raise exc
         except Exception as exc:
             msg.chan_exc = exc
             msg.chan_exc_traceback = traceback.format_exc()
             self.logger.error('Error while processing message %s (chan %s)', str(msg), str(self))
-            await self.message_store.change_message_state(msg.store_id, message.Message.ERROR)
             await self.message_store.add_message_meta_infos(msg.store_id, "err_msg", str(exc))
-            if not self._has_callback():
-                await self._call_fail_nodes(msg=msg)
+            if not self._has_callback() and call_endnodes:
+                try:
+                    await self._call_fail_nodes(msg=msg)
+                except exceptions.RetryException as retry_exc:
+                    self.logger.info("%s CATCH RETRY in fail nodes for msg %s", str(self), str(msg))
+                    retry_exc_catched = retry_exc
             raise
         finally:
-            self.status = BaseChannel.WAITING
-            self.processed_msgs += 1
-            if not self._has_callback():
-                await self._call_final_nodes(msg=msg)
+            if set_state and not retry_exc_catched and self.has_message_store:
+                await self.message_store.set_state_to_worst_sub_state(msg.store_id)
+            if not retry_exc_catched:
+                if not self._has_callback() and call_endnodes:
+                    await self._call_final_nodes(msg=msg)
             try:
                 if self.sub_chan_tasks:
                     # Launch sub chans handle()
@@ -525,8 +568,17 @@ class BaseChannel:
                     if self.wait_subchans:
                         await subchan_endnodes_fut
                 self.logger.info("%s end handle %s", str(self), str(msg))
+            if retry_exc_catched:
+                raise retry_exc_catched
 
-    async def inject(self, msg, start_nodename):
+    async def _get_base_msg_from_child(self, msg):
+        base_msg_data = await self.message_store.get(msg.store_id)
+        base_msg = base_msg_data["message"]
+        base_msg.store_id = msg.store_id
+        base_msg.store_chan_name = self.short_name
+        return base_msg
+
+    async def inject(self, msg, start_nodename, call_endnodes=True, set_state=True):
         """
         Inject a message at a given node name
 
@@ -534,44 +586,93 @@ class BaseChannel:
             msg (message.Message): Message to inject
             start_nodename (str): Node name where inject the message
         """
-        if not start_nodename or start_nodename == "_initial":
-            result = await self._call_base_handling(
-                msg=msg, start_nodename=start_nodename)
-            return result
+        logger.debug(f"{self.short_name} Inject {msg} in {start_nodename}")
 
-        start_node = self.get_node(name=start_nodename)
-        if not start_node:
-            raise ValueError("Node %s not found", start_nodename)
-        logger.debug("Will inject msg %r in node %r", msg, start_node)
-        if start_node in self.init_nodes:
-            msg = await self._call_init_nodes(msg=msg, start_nodename=start_nodename)
-            await self._call_base_handling(msg=msg, start_nodename="_initial")
-        elif start_node in self._nodes:
-            await self._call_base_handling(msg=msg, start_nodename=start_nodename)
-        elif start_node in self.join_nodes:
-            await self._call_join_nodes(msg=msg, start_nodename=start_nodename)
-            base_msg_data = await self.message_store.get(msg.store_id)
-            base_msg = base_msg_data["message"]
-            await self._call_final_nodes(msg=base_msg)
-        elif start_node in self.drop_nodes:
-            await self._call_drop_nodes(msg=msg, start_nodename=start_nodename)
-            base_msg_data = await self.message_store.get(msg.store_id)
-            base_msg = base_msg_data["message"]
-            await self._call_final_nodes(msg=base_msg)
-        elif start_node in self.reject_nodes:
-            await self._call_reject_nodes(msg=msg, start_nodename=start_nodename)
-            base_msg_data = await self.message_store.get(msg.store_id)
-            base_msg = base_msg_data["message"]
-            await self._call_final_nodes(msg=base_msg)
-        elif start_node in self.fail_nodes:
-            await self._call_fail_nodes(msg=msg, start_nodename=start_nodename)
-            base_msg_data = await self.message_store.get(msg.store_id)
-            base_msg = base_msg_data["message"]
-            await self._call_final_nodes(msg=base_msg)
-        elif start_node in self.final_nodes:
-            await self._call_final_nodes(msg=msg, start_nodename=start_nodename)
-        else:
-            raise Exception("Node %r found but not in init/handle/end nodes, weird..", start_node)
+        async with self.lock:
+            if not start_nodename or start_nodename == "_initial":
+                result = await self._call_base_handling(
+                    msg=msg, start_nodename=start_nodename, call_endnodes=call_endnodes,
+                    set_state=set_state)
+                return result
+
+            start_node = self.get_node(name=start_nodename)
+            if not start_node:
+                raise ValueError("Node %s not found", start_nodename)
+            logger.debug("Will inject msg %r in node %r", msg, start_node)
+            if self.init_nodes and start_node in self.init_nodes:
+                msg = await self._call_init_nodes(msg=msg, start_nodename=start_nodename)
+                result = await self._call_base_handling(
+                    msg=msg, start_nodename="_initial",
+                    call_endnodes=call_endnodes, set_state=set_state)
+                return result
+            elif start_node in self._nodes:
+                result = await self._call_base_handling(
+                    msg=msg, start_nodename=start_nodename,
+                    call_endnodes=call_endnodes, set_state=set_state
+                )
+                return result
+
+            if set_state and self.has_message_store:
+                # TODO: Must set the final state after end nodes
+                await self.message_store.set_state_to_worst_sub_state(msg.store_id)
+
+            # TODO: there's a difference between the inject and the classic handle in
+            # how endnodes are processed:
+            # In handle, if an error occur during join nodes call, it'll call fail/drop/reject
+            # nodes, here it's not the case
+            # I don't actually know if I have to change the handle or the inject
+            if self.join_nodes and start_node in self.join_nodes:
+                exc_to_raise = None
+                try:
+                    await self._call_join_nodes(msg=msg, start_nodename=start_nodename)
+                except exceptions.RetryException as exc:
+                    raise exc
+                except Exception as exc:
+                    exc_to_raise = exc
+                base_msg = await self._get_base_msg_from_child(msg)
+                await self._call_final_nodes(msg=base_msg)
+                if exc_to_raise is not None:
+                    raise exc_to_raise
+            elif self.drop_nodes and start_node in self.drop_nodes:
+                exc_to_raise = None
+                try:
+                    await self._call_drop_nodes(msg=msg, start_nodename=start_nodename)
+                except exceptions.RetryException as exc:
+                    raise exc
+                except Exception as exc:
+                    exc_to_raise = exc
+                base_msg = await self._get_base_msg_from_child(msg)
+                await self._call_final_nodes(msg=base_msg)
+                if exc_to_raise is not None:
+                    raise exc_to_raise
+            elif self.reject_nodes and start_node in self.reject_nodes:
+                exc_to_raise = None
+                try:
+                    await self._call_reject_nodes(msg=msg, start_nodename=start_nodename)
+                except exceptions.RetryException as exc:
+                    raise exc
+                except Exception as exc:
+                    exc_to_raise = exc
+                base_msg = await self._get_base_msg_from_child(msg)
+                await self._call_final_nodes(msg=base_msg)
+                if exc_to_raise is not None:
+                    raise exc_to_raise
+            elif self.fail_nodes and start_node in self.fail_nodes:
+                exc_to_raise = None
+                try:
+                    await self._call_fail_nodes(msg=msg, start_nodename=start_nodename)
+                except exceptions.RetryException as exc:
+                    raise exc
+                except Exception as exc:
+                    exc_to_raise = exc
+                base_msg = await self._get_base_msg_from_child(msg)
+                await self._call_final_nodes(msg=base_msg)
+                if exc_to_raise is not None:
+                    raise exc_to_raise
+            elif self.final_nodes and start_node in self.final_nodes:
+                await self._call_final_nodes(msg=msg, start_nodename=start_nodename)
+            else:
+                raise Exception("Node %r found but not in init/handle/end nodes, weird..", start_node)
 
     async def handle(self, msg):
         """ Overload this method only if you know what you are doing but
@@ -581,7 +682,6 @@ class BaseChannel:
 
         :return: Processed message
         """
-
         # Store message before any processing
         # TODO If store fails, do we stop processing ?
         # TODO Do we store message even if channel is stopped ?
@@ -589,6 +689,7 @@ class BaseChannel:
         if msg_store_id is not None:
             msg.store_id = msg_store_id
             msg.store_chan_name = self.short_name
+        # await self.message_store.change_message_state(msg.store_id, message.Message.PENDING)  TODO
 
         if self.status in [BaseChannel.STOPPED, BaseChannel.STOPPING]:
             raise ChannelStopped("Channel is stopped so you can't send message.")
@@ -598,8 +699,28 @@ class BaseChannel:
         setattr(msg, "chan_exc_traceback", None)
         # Only one message processing at time
         async with self.lock:
-            self.status = BaseChannel.PROCESSING
-            return await self._call_base_handling(msg=msg)
+            if self.status == BaseChannel.PAUSED:
+                await self.message_store.change_message_state(msg.store_id, message.Message.WAIT_RETRY)
+                if self.retry_store:
+                    await self.retry_store.store_until_retry(msg=msg, nodename=None)
+                raise exceptions.PausedChanException(
+                    "Channel %s in pause state, put message in retry store",
+                    self.short_name
+                )
+            else:
+                self.status = BaseChannel.PROCESSING
+            await self.message_store.add_sub_message_state(
+                id=msg.store_id, sub_id=msg.store_id, state=message.Message.PROCESSING)
+            try:
+                return await self._call_base_handling(msg=msg)
+            except exceptions.RetryException as exc:
+                self.logger.warning("Retry Exception catch: Set Channel in retry mode")
+                self.status = BaseChannel.PAUSED
+                raise exceptions.PausedChanException(exc)
+            finally:
+                self.processed_msgs += 1
+                if self.status == BaseChannel.PROCESSING:
+                    self.status = BaseChannel.WAITING
 
     async def subhandle(self, msg, start_nodename=None):
         """ Overload this method only if you know what you are doing. Called by ``handle`` method.
@@ -613,7 +734,7 @@ class BaseChannel:
 
         return result
 
-    async def _process_nodes(self, nodes, msg):
+    async def _process_nodes(self, nodes, msg, add_sub_state=True):
         """
         Pass the msg to a list of nodes
 
@@ -621,6 +742,17 @@ class BaseChannel:
             nodes (list of nodes.BaseNode objects): List of nodes to traverse in order
             msg (message.Message): Message to process
         """
+        if add_sub_state:
+            msg_store_id = msg.store_id
+        else:
+            msg_store_id = None
+        msg_store = None
+        msg_store_chan = msg.store_chan_name
+        if msg_store_id and msg_store_chan:
+            if msg_store_chan == self.short_name:
+                msg_store = self.message_store
+            else:
+                msg_store = get_channel(name=msg_store_chan).message_store
         cur_res = msg
         for cur_node_idx, node in enumerate(nodes):
             if isinstance(cur_res, types.GeneratorType):
@@ -629,14 +761,25 @@ class BaseChannel:
                 gene = cur_res
                 raised_drop = None
                 raised_exc = None
+                raised_retry_exc = None
                 for gen_msg in gene:
+                    if raised_retry_exc and self.retry_store:
+                        await self.retry_store.store_until_retry(
+                            msg=gen_msg,
+                            nodename=nodes[cur_node_idx].name,
+                        )
+                        continue
                     try:
                         result = await self._process_nodes(nodes=nodes[cur_node_idx:], msg=gen_msg)
+                    except exceptions.RetryException as exc:
+                        raised_retry_exc = exc
                     except Dropped as exc:
                         raised_drop = exc
                     except Exception as exc:
                         raised_exc = exc
-                if raised_exc is not None:
+                if raised_retry_exc is not None:
+                    raise raised_retry_exc
+                elif raised_exc is not None:
                     raise raised_exc
                 elif raised_drop is not None:
                     raise raised_drop
@@ -646,12 +789,51 @@ class BaseChannel:
                     # approach
                     return result
             else:
+                cur_msg_uuid = getattr(cur_res, "uuid", None)
                 try:
                     res = await node.handle(cur_res.copy())
                 except EndChanProcess:
                     logger.debug("EndChanProcess raised, ending channel process..")
+                    if msg_store:
+                        await msg_store.add_sub_message_state(
+                            id=msg_store_id,
+                            sub_id=cur_msg_uuid,
+                            state=message.Message.PROCESSED,
+                        )
                     return cur_res
+                except Dropped as exc:
+                    if msg_store:
+                        await msg_store.add_sub_message_state(
+                            id=msg_store_id,
+                            sub_id=cur_msg_uuid,
+                            state=message.Message.PROCESSED,
+                        )
+                    raise exc
+                except Rejected as exc:
+                    if msg_store:
+                        await msg_store.add_sub_message_state(
+                            id=msg_store_id,
+                            sub_id=cur_msg_uuid,
+                            state=message.Message.REJECTED,
+                        )
+                    raise exc
+                except (exceptions.RetryException, exceptions.PausedChanException):
+                    raise
+                except Exception as exc:
+                    if msg_store:
+                        await msg_store.add_sub_message_state(
+                            id=msg_store_id,
+                            sub_id=cur_msg_uuid,
+                            state=message.Message.ERROR,
+                        )
+                    raise exc
                 cur_res = res
+        if msg_store:
+            await msg_store.add_sub_message_state(
+                id=msg_store_id,
+                sub_id=cur_msg_uuid,
+                state=message.Message.PROCESSED,
+            )
         return cur_res
 
     async def process(self, msg, start_nodename=None):
@@ -696,7 +878,7 @@ class BaseChannel:
             'short_name': self.short_name,
             'verbose_name': self.verbose_name,
             'status': BaseChannel.status_id_to_str(self.status),
-            'has_message_store': not isinstance(self.message_store, msgstore.NullMessageStore),
+            'has_message_store': self.has_message_store,
             'processed': self.processed_msgs,
         }
 
@@ -903,9 +1085,17 @@ class SubChannel(BaseChannel):
         setattr(entrymsg, "chan_exc", None)
         setattr(entrymsg, "chan_exc_traceback", None)
         endnodes_tasks = []
+        retry_exc = None
         try:
             result = fut.result()
             entrymsg.chan_rslt = result
+            if self.join_nodes:
+                endnode_task = asyncio.create_task(self._call_join_nodes(result.copy()))
+                endnodes_tasks.append(endnode_task)
+            logger.info(
+                "Subchannel %s end process message %s, rslt is msg %s",
+                str(self), str(entrymsg), str(result))
+        except EndChanProcess:
             if self.join_nodes:
                 endnode_task = asyncio.create_task(self._call_join_nodes(result.copy()))
                 endnodes_tasks.append(endnode_task)
@@ -927,6 +1117,9 @@ class SubChannel(BaseChannel):
                 endnodes_tasks.append(endnode_task)
             self.logger.info("Subchannel %s. Msg %s was Rejected", str(self), str(entrymsg))
             raise
+        except exceptions.RetryException as exc:
+            retry_exc = exc
+            raise exc
         except Exception as exc:
             entrymsg.chan_exc = exc
             entrymsg.chan_exc_traceback = traceback.format_exc()
@@ -937,7 +1130,7 @@ class SubChannel(BaseChannel):
                 "Error while processing msg %s in subchannel %s", str(entrymsg), str(self))
             raise
         finally:
-            if self.final_nodes:
+            if self.final_nodes and not retry_exc:
                 endnode_task = asyncio.create_task(self._call_final_nodes(entrymsg.copy()))
                 endnodes_tasks.append(endnode_task)
             self.parent.sub_chan_endnodes.extend(endnodes_tasks)
@@ -948,7 +1141,13 @@ class SubChannel(BaseChannel):
     async def subhandle(self, msg, start_nodename=None):
         msgctxvartoken = MSG_CTXVAR.set(msg.copy())
         ctx = contextvars.copy_context()
-        fut = asyncio.create_task(self.process(msg.copy(), start_nodename=start_nodename))
+        copied_msg = msg.copy()
+        if not self.has_message_store:
+            # Reset the store id of the message to avoid adding sub messages status
+            # of subchannel to the first message
+            copied_msg.store_id = None
+            copied_msg.store_chan_name = None
+        fut = asyncio.create_task(self.process(copied_msg, start_nodename=start_nodename))
         fut.add_done_callback(self._callback, context=ctx)
         self.parent.sub_chan_tasks.append(fut)
         MSG_CTXVAR.reset(msgctxvartoken)

--- a/pypeman/exceptions.py
+++ b/pypeman/exceptions.py
@@ -30,6 +30,5 @@ class RetryException(Exception):
 
 class PausedChanException(Exception):
     """
-        Custom Exception that is raise when a pypeman channel that have a messages
-        store catch a retry exception.
+        Custom Exception that is raise when a pypeman channel is paused
     """

--- a/pypeman/exceptions.py
+++ b/pypeman/exceptions.py
@@ -19,3 +19,18 @@ class Rejected(Exception):
 class ChannelStopped(Exception):
     """ The channel is stopped and can't process message.
     """
+
+
+class RetryException(Exception):
+    """
+        Custom Exception that is raise when a pypeman node catch an exception
+        that should trigger a delayed relaunch of the msg.
+    """
+
+
+class PausedChanException(Exception):
+    """
+        Custom Exception that is raise when a pypeman channel that have a messages
+        store catch a retry exception.
+        Considered as a message error
+    """

--- a/pypeman/exceptions.py
+++ b/pypeman/exceptions.py
@@ -32,5 +32,4 @@ class PausedChanException(Exception):
     """
         Custom Exception that is raise when a pypeman channel that have a messages
         store catch a retry exception.
-        Considered as a message error
     """

--- a/pypeman/message.py
+++ b/pypeman/message.py
@@ -38,8 +38,9 @@ class Message():
     ERROR = "error"
     REJECTED = "rejected"
     PROCESSED = "processed"
-    store_id = None
-    store_chan_name = None
+    WAIT_RETRY = "wait_retry"
+    # Status priority: less important first
+    STATES_PRIORITY = [WAIT_RETRY, PENDING, PROCESSING, PROCESSED, REJECTED, ERROR]
 
     def __init__(self, content_type='application/text', payload=None, meta=None):
         self.content_type = content_type
@@ -51,6 +52,8 @@ class Message():
         if meta is None:
             meta = {}
         self.meta = meta
+        self.store_id = None
+        self.store_chan_name = None
 
         self.ctx = {}
 
@@ -100,6 +103,8 @@ class Message():
         result = {}
         result['timestamp'] = self.timestamp.strftime(DATE_FORMAT)
         result['uuid'] = self.uuid
+        result['store_id'] = self.store_id
+        result['store_chan_name'] = self.store_chan_name
         if encode_payload:
             result['payload'] = base64.b64encode(pickle.dumps(self.payload)).decode('ascii')
         else:
@@ -139,6 +144,8 @@ class Message():
         result.uuid = UUID(data['uuid']).hex
         result.payload = pickle.loads(base64.b64decode(data['payload'].encode('ascii')))
         result.meta = data['meta']
+        result.store_id = data.get('store_id')
+        result.store_chan_name = data.get('store_chan_name')
 
         for k, ctx_msg in data['ctx'].items():
             result.ctx[k] = {}

--- a/pypeman/message.py
+++ b/pypeman/message.py
@@ -52,7 +52,15 @@ class Message():
         if meta is None:
             meta = {}
         self.meta = meta
+        # store_id is the id in the message store for this message
+        # If base message is yielded, each submessage keep the origin store_id
+        # Caution: in case of a subchannel, the store_id is removed as the subchannel doesn't
+        # have to influence the base message
         self.store_id = None
+        # store_chan_name is the short name of the channel that lastly store this message or one of
+        # it's parent
+        # Caution: Same as store_id, if the message enter in a subchannel that doesn't have a
+        # configured message store, this attr is set to None
         self.store_chan_name = None
 
         self.ctx = {}

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -118,7 +118,7 @@ class BaseNode:
 
     _used_names = set()  # already used node names to ensure uniqueness
 
-    def __init__(self, *args, name=None, log_output=False, auto_retry_exceptions=[],
+    def __init__(self, *args, name=None, log_output=False, auto_retry_exceptions=(),
                  **kwargs):
         cls = self.__class__
         self.channel = None
@@ -172,7 +172,8 @@ class BaseNode:
         # TODO : Make sure exceptions are well raised (does not happen if i.e 1/0 here atm)
         if self.store_input_as:
             msg.add_context(self.store_input_as, msg)
-        old_msg = msg.copy()
+        if self.passthrough or self.auto_retry_exceptions:
+            old_msg = msg.copy()
         # Allow process as coroutine function
         if self.auto_retry_exceptions:
             try:

--- a/pypeman/retry.py
+++ b/pypeman/retry.py
@@ -1,0 +1,203 @@
+import asyncio
+import logging
+import os
+
+from pathlib import Path
+
+from pypeman import exceptions
+from pypeman.msgstore import FileMessageStore
+
+logger = logging.getLogger(__name__)
+
+
+class RetryFileMsgStore(FileMessageStore):
+    STOPPED = "STOPPED"
+    RETRY_MODE = "RETRY_MODE"
+    state = None
+
+    def __init__(self, *args, path, channel, retry_delay=60, **kwargs):
+        path = os.path.join(path, "retry_store")
+        self.retry_delay = retry_delay  # delay in seconds between retries
+        self.channel = channel
+        self.state = self.STOPPED
+        self.stop_flag = False
+        self.retry_task = None
+        self.exit_event = asyncio.Event()
+        self.test_mode = False
+        super().__init__(*args, path=path, **kwargs)
+
+    def _reset_test(self):
+        """
+            If test mode is set to True, don't start the retry task,
+            you must call retry method manually
+        """
+        self.test_mode = True
+
+    async def start(self):
+        await super().start()
+        cnt_msgs = await self.count_msgs()
+        if cnt_msgs > 0:
+            await self.start_retry_mode()
+
+    async def stop(self):
+        if self.state != self.STOPPED:
+            self.exit_event.set()
+            if self.retry_task:
+                await asyncio.gather(self.retry_task)
+
+    async def store_until_retry(self, msg, nodename):
+        logger.debug(f"Retrystore of {self.channel.short_name} Store msg {msg}")
+        store_id = msg.store_id
+        store_chan_name = msg.store_chan_name
+        id = await self.store(msg=msg)
+        await self.add_message_meta_infos(id=id, meta_info_name="nodename", info=nodename)
+        await self.add_message_meta_infos(id=id, meta_info_name="store_id", info=store_id)
+        await self.add_message_meta_infos(id=id, meta_info_name="store_chan_name", info=store_chan_name)
+        if self.state != self.RETRY_MODE:
+            await self.start_retry_mode()
+
+    async def search_by_store_id(self, store_id, count=0):
+        """Returns a list of <count> messages ids for a given store_id
+        if count is 0|False|None, returns all messages for this id
+
+        Args:
+            store_id (str|None): The store_id to search in meta
+            count (int): The number of maximum wanted results (if set to 0, unlimited)
+
+        Returns:
+            list of str: list of message ids
+        """
+        msg_ids_to_return = []
+        for year in await self.sorted_list_directories(os.path.join(self.base_path)):
+            for month in await self.sorted_list_directories(
+                    os.path.join(self.base_path, year)):
+                for day in await self.sorted_list_directories(
+                        os.path.join(self.base_path, year, month)):
+                    folder_path = Path(self.base_path) / year / month / day
+                    for fpath in folder_path.glob("*.meta"):
+                        msg_id = fpath.stem
+                        msg_store_id = await self.get_message_meta_infos(
+                            id=msg_id, meta_info_name="store_id")
+                        if msg_store_id == store_id:
+                            msg_ids_to_return.append(msg_id)
+                        if count:
+                            if len(msg_ids_to_return) == count:
+                                return msg_ids_to_return
+        return msg_ids_to_return
+
+    async def retry_one_store_id(self, msg_store_id):
+        if msg_store_id is not None:
+            msg_ids = await self.search_by_store_id(store_id=msg_store_id)
+        else:
+            msg_ids = await self.search_by_store_id(store_id=msg_store_id, count=1)
+
+        logger.debug(
+            f"Retrystore of {self.channel.short_name} try to retry "
+            f"store_id={msg_store_id} ({len(msg_ids)} messages)"
+        )
+        # TODO: at moment, the retry store don't handle order of yielded sub messages
+        # as they don't provide their order
+        catched_exc = None
+        for idx, msg_id in enumerate(msg_ids):
+            msg_data = await self.get(id=msg_id)
+            nodename_where_inject = msg_data["meta"]["nodename"]
+            msg_store_id = msg_data["meta"]["store_id"]
+            msg_store_chan_name = msg_data["meta"]["store_chan_name"]
+            chan = self.channel
+            msg = msg_data["message"]
+            msg.store_id = msg_store_id
+            msg.store_chan_name = msg_store_chan_name
+            await self.delete(id=msg_id)
+            is_last_msg = idx == len(msg_ids) - 1
+            # TODO: currently, inject doesn't work with endnodes as it don't get the worst
+            # state to call correct nodes: I'll implement it in future weeks
+            # It needs a little refactorisation of how "special" nodes are called
+            call_endnodes = nodename_where_inject is None
+            try:
+                await chan.inject(
+                    msg=msg,
+                    start_nodename=nodename_where_inject,
+                    call_endnodes=call_endnodes,
+                    set_state=is_last_msg,
+                )
+            except exceptions.RetryException:
+                raise
+            except Exception as exc:
+                catched_exc = exc
+        if catched_exc is not None:
+            raise catched_exc
+
+    async def _set_base_msg_state(self, msg_data):
+        from pypeman.channels import get_channel
+        msg_store_chan_name = msg_data["meta"]["store_chan_name"]
+        msg_store_id = msg_data["meta"]["store_id"]
+        if not (msg_store_chan_name or msg_store_chan_name):
+            return
+        if msg_store_chan_name != self.channel.short_name:
+            msg_store = get_channel(msg_store_chan_name).message_store
+        else:
+            msg_store = self.channel.message_store
+
+        if msg_store and msg_store_id:
+            await msg_store.set_state_to_worst_sub_state(msg_store_id)
+
+    async def retry(self):
+        """
+        Launch retry for all messages until all messages are processed or until the
+        first RetryException catch
+        """
+        from pypeman.channels import BaseChannel
+        logger.debug(f"Retrystore of {self.channel.short_name} try to retry")
+        while self.state == self.RETRY_MODE and not self.exit_event.is_set():
+            async with self.channel.lock:
+                msgs_data = await self.search(count=1, order_by="timestamp")
+                if len(msgs_data) == 0:
+                    logger.debug("No more messages to reply, chan will be un-paused")
+                    self.channel.status = BaseChannel.WAITING
+                    self.state = self.STOPPED
+                    break
+                else:
+                    msg_data = msgs_data[0]
+                    message_store_id = msg_data["meta"]["store_id"]
+            retry_exc_catched = False
+            try:
+                await self.retry_one_store_id(msg_store_id=message_store_id)
+                logger.debug(
+                    f"Retrystore Retry {self.channel.short_name}: Retry of "
+                    f"store_id={ message_store_id } Done"
+                )
+                continue
+            except exceptions.RetryException:
+                logger.debug(
+                    f"Retrystore Retry {self.channel.short_name}: Retry of "
+                    f"store_id={ message_store_id } not good: RetryExc catched,"
+                    " will retry later"
+                )
+                retry_exc_catched = True
+                return
+            except Exception:
+                logger.debug(
+                    f"Retrystore Retry {self.channel.short_name}: Retry of "
+                    f"store_id={ message_store_id } Done (with err)"
+                )
+                continue
+            finally:
+                if not retry_exc_catched:
+                    await self._set_base_msg_state(msg_data)
+
+    async def start_retry_mode(self):
+        from pypeman.channels import BaseChannel
+        logger.debug(f"Retrystore of {self.channel.short_name} start retry mode")
+        self.state = self.RETRY_MODE
+        if self.channel.status != BaseChannel.PAUSED:
+            self.channel.status = BaseChannel.PAUSED
+        if not self.test_mode:
+            self.retry_task = asyncio.create_task(self.wait_retries())
+
+    async def wait_retries(self):
+        while self.state == self.RETRY_MODE and not self.exit_event.is_set():
+            await self.retry()
+            try:
+                await asyncio.wait_for(self.exit_event.wait(), timeout=self.retry_delay)
+            except asyncio.TimeoutError:
+                pass

--- a/pypeman/retry.py
+++ b/pypeman/retry.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 class RetryFileMsgStore(FileMessageStore):
     """
-    A class that is attached to a channel and permits auto replaying message that
-    is stored in it after a given time.
+    A class that is attached to a channel and automatically replays messages that
+    are stored in it after a given time.
     Nodes that catch specific exceptions add the message in this filestore, the
-    retryfilestore will pause the attached channel if it's not the case and will retry
+    retryfilestore will pause the attached channel and will retry
     to inject the message after a given time. If the message continue to fail, it will
     re-wait and re-try.
     If the message is successfully injected, it will be remove from the message store.

--- a/pypeman/retry.py
+++ b/pypeman/retry.py
@@ -76,7 +76,7 @@ class RetryFileMsgStore(FileMessageStore):
 
     async def search_by_store_id(self, store_id, count=0):
         """Returns a list of <count> messages ids for a given store_id
-        if count is 0|False|None, returns all messages for this id
+        if count is 0, returns all messages for this id
 
         Args:
             store_id (str|None): The store_id to search in meta
@@ -105,7 +105,7 @@ class RetryFileMsgStore(FileMessageStore):
 
     async def retry_one_store_id(self, msg_store_id):
         """
-        Launch retry of 1 Base message (as a base message could have be
+        Launch retry of 1 Base message (as a base message could have been
         yielded into multiple sub messages, this function could run the retry of
         multiples sub-messages)
 
@@ -121,7 +121,7 @@ class RetryFileMsgStore(FileMessageStore):
             f"Retrystore of {self.channel.short_name} try to retry "
             f"store_id={msg_store_id} ({len(msg_ids)} messages)"
         )
-        # TODO: at moment, the retry store don't handle order of yielded sub messages
+        # TODO: at moment, the retry store doesn't handle order of yielded sub messages
         # as they don't provide their order
         catched_exc = None
         for idx, msg_id in enumerate(msg_ids):

--- a/pypeman/tests/common.py
+++ b/pypeman/tests/common.py
@@ -62,8 +62,6 @@ def generate_msg(timestamp=None, message_content=default_message_content,
             m.timestamp = datetime.datetime(*timestamp)
         else:  # assume it's a datetime object
             m.timestamp = timestamp
-    else:  # just use current time
-        m.timestamp = datetime.datetime.utcnow()
 
     m.payload = message_content
 

--- a/pypeman/tests/settings/test_settings_retry_store.py
+++ b/pypeman/tests/settings/test_settings_retry_store.py
@@ -1,0 +1,5 @@
+import tempfile
+from pathlib import Path
+
+TEMPDIR = tempfile.TemporaryDirectory()
+RETRY_STORE_PATH = Path(TEMPDIR.name)

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -719,6 +719,9 @@ class ChannelsTests(TestCase):
         self.assertTrue(
             sub2_endok1.processed,
             "subchan2 ok_endnodes1 not called")
+        print("mimimimimi")
+        print(vars(self.clean_msg(startmsg)))
+        print(vars(self.clean_msg(sub2_endok1.last_input())))
         self.assertDictEqual(
             vars(self.clean_msg(startmsg)), vars(self.clean_msg(sub2_endok1.last_input())),
             "subchan2 ok_endnodes don't takes event msg in input")
@@ -1382,9 +1385,10 @@ class ChannelsTests(TestCase):
         msg1 = generate_msg(message_content="msg1")
         self.start_channels()
         msg1.store_id = self.loop.run_until_complete(chan.message_store.store(msg1))
+        msg1.store_chan_name = chan.short_name
         self.loop.run_until_complete(chan.message_store.change_message_state(
             msg1.store_id,
-            message.Message.PENDING,
+            message.Message.WAIT_RETRY,
         ))
         init_node_1 = chan.get_node("CHAN_TEST_INJECTION_init_1")
         init_node_2 = chan.get_node("CHAN_TEST_INJECTION_init_2")
@@ -1437,7 +1441,7 @@ class ChannelsTests(TestCase):
         print("Test inject in handle node")
         self.loop.run_until_complete(chan.message_store.change_message_state(
             msg1.store_id,
-            message.Message.ERROR,
+            message.Message.WAIT_RETRY,
         ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
@@ -1472,6 +1476,10 @@ class ChannelsTests(TestCase):
 
         # Test inject in join nodes
         print("Test inject in join node")
+        self.loop.run_until_complete(chan.message_store.change_message_state(
+            msg1.store_id,
+            message.Message.PROCESSED,
+        ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
             msg=msg1,
@@ -1502,6 +1510,10 @@ class ChannelsTests(TestCase):
 
         # Test inject in drop nodes
         print("Test inject in drop node")
+        self.loop.run_until_complete(chan.message_store.change_message_state(
+            msg1.store_id,
+            message.Message.PROCESSED,
+        ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
             msg=msg1,
@@ -1532,6 +1544,10 @@ class ChannelsTests(TestCase):
 
         # Test inject in reject nodes
         print("Test inject in reject node")
+        self.loop.run_until_complete(chan.message_store.change_message_state(
+            msg1.store_id,
+            message.Message.REJECTED,
+        ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
             msg=msg1,
@@ -1562,6 +1578,10 @@ class ChannelsTests(TestCase):
 
         # Test inject in fail nodes
         print("Test inject in fail node")
+        self.loop.run_until_complete(chan.message_store.change_message_state(
+            msg1.store_id,
+            message.Message.ERROR,
+        ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
             msg=msg1,
@@ -1592,6 +1612,10 @@ class ChannelsTests(TestCase):
 
         # Test inject in final nodes
         print("Test inject in final node")
+        self.loop.run_until_complete(chan.message_store.change_message_state(
+            msg1.store_id,
+            message.Message.PROCESSED,
+        ))
         chan._reset_test()
         self.loop.run_until_complete(chan.inject(
             msg=msg1,

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -719,9 +719,6 @@ class ChannelsTests(TestCase):
         self.assertTrue(
             sub2_endok1.processed,
             "subchan2 ok_endnodes1 not called")
-        print("mimimimimi")
-        print(vars(self.clean_msg(startmsg)))
-        print(vars(self.clean_msg(sub2_endok1.last_input())))
         self.assertDictEqual(
             vars(self.clean_msg(startmsg)), vars(self.clean_msg(sub2_endok1.last_input())),
             "subchan2 ok_endnodes don't takes event msg in input")

--- a/pypeman/tests/test_msgstore.py
+++ b/pypeman/tests/test_msgstore.py
@@ -330,15 +330,15 @@ class MsgstoreTests(TestCase):
 
         # Test processed message
         dict_msg = self.loop.run_until_complete(
-            chan.message_store.get('19821128_1235_%s' % msg3.uuid))
+            chan.message_store.get('19821128_123500000000_%s' % msg3.uuid))
         self.assertEqual(dict_msg['state'], 'processed', "Message %s should be in processed state!" % msg3)
 
         # Test failed message
         dict_msg = self.loop.run_until_complete(
-            chan.message_store.get('19821112_1435_%s' % msg5.uuid))
+            chan.message_store.get('19821112_143500000000_%s' % msg5.uuid))
         self.assertEqual(dict_msg['state'], 'error', "Message %s should be in error state!" % msg5)
 
-        self.assertTrue(os.path.exists("%s/%s/1982/11/28/19821128_1235_%s"
+        self.assertTrue(os.path.exists("%s/%s/1982/11/28/19821128_123500000000_%s"
                         % (tempdir, chan.name, msg3.uuid)))
 
         # Test list messages
@@ -362,12 +362,12 @@ class MsgstoreTests(TestCase):
 
         # Test view message
         msg_content = self.loop.run_until_complete(chan.message_store.get_msg_content(
-            '19821112_1435_%s' % msg5.uuid))
+            '19821112_143500000000_%s' % msg5.uuid))
         self.assertEqual(msg_content.payload, msg5.payload, "Failure of message %s view!" % msg5)
 
         # Test preview message
         msg_content = self.loop.run_until_complete(chan.message_store.get_preview_str(
-            '19821112_1435_%s' % msg5.uuid))
+            '19821112_143500000000_%s' % msg5.uuid))
         self.assertEqual(msg_content.payload, msg5.payload[:1000], "Failure of message %s preview!" % msg5)
 
         self.clean_loop()

--- a/pypeman/tests/test_retrystore.py
+++ b/pypeman/tests/test_retrystore.py
@@ -1,0 +1,752 @@
+import asyncio
+import copy
+import logging
+
+from pypeman import channels, endpoints
+from pypeman import conf
+from pypeman import nodes
+from pypeman import msgstore
+from pypeman import message
+from pypeman.channels import BaseChannel, Rejected
+from pypeman.retry import RetryFileMsgStore
+from pypeman import exceptions
+from pypeman.test import TearDownProjectTestCase as TestCase
+from pypeman.tests.common import generate_msg
+from pypeman.tests.common import setup_settings
+from pypeman.tests.common import teardown_settings
+
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_MODULE = 'pypeman.tests.settings.test_settings_retry_store'
+
+
+class TstExcNode(nodes.BaseNode):
+    def __init__(self, *args, exc=KeyError, raise_exc=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exc = exc
+        self.raise_exc = raise_exc
+
+    async def process(self, msg):
+        if self.raise_exc:
+            raise self.exc("Custom KeyError Exc raised")
+        print(msg)
+        return msg
+
+
+class RetryStoreTests(TestCase):
+    def clean_loop(self):
+        # Useful to execute future callbacks  # TODO: remove ?
+        pending = asyncio.all_tasks(loop=self.loop)
+
+        if pending:
+            self.loop.run_until_complete(asyncio.gather(*pending))
+        self.loop.stop()
+        self.loop.close()
+
+    def start_channels(self):
+        # Start channels
+        for chan in channels.all_channels:
+            self.loop.run_until_complete(chan.start())
+
+    def setUp(self):
+        # Create class event loop used for tests to avoid failing
+        # previous tests to impact next test ? (Not sure)
+        self.loop = asyncio.new_event_loop()
+        self.loop.set_debug(True)
+        # Remove thread event loop to be sure we are not using
+        # another event loop somewhere
+        asyncio.set_event_loop(None)
+
+        # Avoid calling already tested channels
+        channels.all_channels.clear()
+        setup_settings(SETTINGS_MODULE)  # adapt config
+        conf.settings.init_settings()
+
+    def tearDown(self):
+        super().tearDown()
+
+        for end in endpoints.all_endpoints:
+            self.loop.run_until_complete(end.stop())
+
+        # Stop all channels
+        for chan in channels.all_channels:
+            if not chan.is_stopped():
+                self.loop.run_until_complete(chan.stop())
+        self.clean_loop()
+        endpoints.reset_pypeman_endpoints()
+        conf.settings.TEMPDIR.cleanup()
+        teardown_settings()
+
+    def _create_complete_retry_chan(self, base_chan_name="retry_chan"):
+        """Create a complete chan to test retry store
+        The chan graph looks like this:
+
+        BaseChannel (name=retry_chan)
+            |
+        (init node, name=init_node) TstExcNode
+            |
+        (classic node) YielderNode
+            |
+        (classic node, name=first_node) TstExcNode
+            |
+            ---------------------------------------- FORK (name=retry_chan_forked)
+            |                                                    |
+            ---------WHEN (name=retry_chan_cond)      (classic node, name=forked_node) TstExcNode
+            |                  |
+            |     (classic node, name=conditional_node) TstExcNode
+            |
+        (classic node, name=last_node) TstExcNode
+            |
+        ---------------------------------
+        |       |       |       |       |
+        |       |       |       |   (join node, name=join_node) TstExcNode
+        |       |       |   (drop node, name=drop_node) TstExcNode
+        |       |   (reject node, name=reject_node) TstExcNode
+        |   (fail node, name=fail_node) TstExcNode
+        (final node, name=final_node) TstExcNode
+        """
+
+        base_chan = BaseChannel(
+            name=base_chan_name,
+            message_store_factory=msgstore.MemoryMessageStoreFactory(),
+            loop=self.loop,
+        )
+        base_chan.add(
+            nodes.YielderNode(),
+            TstExcNode(
+                name="first_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        forked_chan = base_chan.fork(name=f"{base_chan_name}_forked")
+        forked_chan.add(
+            TstExcNode(
+                name="forked_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        conditional_chan = base_chan.when(lambda msg: msg.payload is True, name=f"{base_chan_name}_cond")
+        conditional_chan.add(
+            TstExcNode(
+                name="conditional_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add(
+            TstExcNode(
+                name="last_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_init_nodes(
+            TstExcNode(
+                name="init_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_join_nodes(
+            TstExcNode(
+                name="join_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_drop_nodes(
+            TstExcNode(
+                name="drop_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_reject_nodes(
+            TstExcNode(
+                name="reject_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_fail_nodes(
+            TstExcNode(
+                name="fail_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        base_chan.add_final_nodes(
+            TstExcNode(
+                name="final_node",
+                auto_retry_exceptions=[KeyError]
+            ),
+        )
+        return base_chan, forked_chan, conditional_chan
+
+    def test_complete_retry(self):
+        """
+        Test Retry store with complete_retry_chan
+
+        The test follow these steps (message.payload=["msg1", "msg2", "msg3"]):
+        - Test with all nodes that raise an error, init node catch the exception store it,
+            put the main channel in Pause state, and set the message state in the "classic"
+            msgstore to "wait_retry"
+        - Retry without modifying nodes (same comportment)
+        - Retry with init_node OK: first_node raise and catch the exception and the 3 yielded
+            submessages are stored in chan retry_store
+        - Retry with first_node OK: last_node raise and catch the exception and the 3 yielded
+            submessages are stored in chan retry_store (and must be inject to first_node or
+            last_node). forked node raise and catch an exception too, Put forked_chan in Pause
+            state, and store the same sub message catched by last_node
+        - Retry with forked_node OK: No changes in base channel and it's retry store, but no
+        more pending message in forked chan's retry store and the chan is un-paused
+        - Retry with last_node OK: The 3 messages are injected, the channel is un-paused and
+            the message state in the msgstore is set to processed. End nodes are not called
+        """
+        chan, forked_chan, conditional_chan = self._create_complete_retry_chan(
+            base_chan_name="comp_retry_chan")
+        msgstore = chan.message_store
+        retry_store = chan.retry_store
+        forked_chan_retry_store = forked_chan.retry_store
+        first_node = chan.get_node("first_node")
+        forked_node = forked_chan.get_node("forked_node")
+        last_node = chan.get_node("last_node")
+        init_node = chan.get_node("init_node")
+
+        msg_payload = ["msg1", "msg2", "msg3"]
+        msg_meta = {"titi": "toto"}
+        msg = generate_msg(message_content=msg_payload, message_meta=msg_meta)
+        chan._reset_test()
+        self.start_channels()
+        print("START CHANNEL")
+
+        print("\n")
+        print("CHANNEL HANDLE 1")
+        # Test with all nodes that raise an error, init node catch the exception store it
+        # Assert:
+        # - the main channel is in Pause state
+        # - the chan retry_store is started and in retry mode
+        # - The stored message state is "wait_retry"
+        # - one message in the retry store
+        # - The only message to retry correspond to base message and have to be inject in
+        #       init_node
+        with self.assertRaises(exceptions.PausedChanException):
+            self.loop.run_until_complete(chan.handle(msg))
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 1
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+        assert msgs_retry_store[0]["message"].payload == stored_msg["message"].payload
+        assert msgs_retry_store[0]["message"].meta == stored_msg["message"].meta
+        assert msgs_retry_store[0]["meta"]["store_id"] == stored_msg["id"]
+        assert msgs_retry_store[0]["meta"]["store_chan_name"] == chan.short_name
+        assert msgs_retry_store[0]["meta"]["nodename"] == init_node.name
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+
+        print("\n")
+        print("RETRY")
+        # Retry without modifying nodes (same comportment as above, no modification)
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 1
+        assert msgs_retry_store[0]["message"].payload == stored_msg["message"].payload
+        assert msgs_retry_store[0]["message"].meta == stored_msg["message"].meta
+        assert msgs_retry_store[0]["meta"]["store_id"] == stored_msg["id"]
+        assert msgs_retry_store[0]["meta"]["store_chan_name"] == chan.short_name
+        assert msgs_retry_store[0]["meta"]["nodename"] == init_node.name
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("RETRY2 init node OK")
+        # Retry with init_node OK: first_node raise and catch the exception
+        # Assert:
+        # - the main chan is already paused
+        # - The 3 yielded submessages are stored in chan retry_store
+        # - They all have to be inject in first_node
+        # - Their payloads corresponds to element in input message's payload list
+        init_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 3
+        copied_msg_payload = copy.deepcopy(msg_payload)
+        for msg_to_retry in msgs_retry_store:
+            retry_msg_payload = msg_to_retry["message"].payload
+            copied_msg_payload.remove(retry_msg_payload)
+            assert msg_to_retry["message"].meta == stored_msg["message"].meta
+            assert msg_to_retry["meta"]["store_id"] == stored_msg["id"]
+            assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+            assert msg_to_retry["meta"]["nodename"] == first_node.name
+        assert len(copied_msg_payload) == 0
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("RETRY3 first node OK")
+        # Retry with first_node OK: last_node raise and catch the exception,
+        # forked_node do the same
+        # Assert for the main chan:
+        # - the chan is already paused
+        # - The 3 yielded submessages are stored in chan retry_store
+        # - One of the 3 messages have to be inject in last_node, others in first_node
+        # - Their payloads corresponds to element in input message's payload list
+        # Assert for the forked chan:
+        # - the chan is in pause state
+        # - the chan retry_store is started and in retry mode
+        # - One submessage in the retry store, and must be inject in forked_node
+        # - The message's payload must correspond to the one catch by last_node
+
+        first_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 3
+        copied_msg_payload = copy.deepcopy(msg_payload)
+        found_msg = None
+        for msg_to_retry in msgs_retry_store:
+            retry_msg_payload = msg_to_retry["message"].payload
+            copied_msg_payload.remove(retry_msg_payload)
+            nodename_where_inject = msg_to_retry["meta"]["nodename"]
+            if nodename_where_inject == first_node.name:
+                continue
+            assert nodename_where_inject == last_node.name
+            found_msg = msg_to_retry
+            assert msg_to_retry["message"].meta == stored_msg["message"].meta
+            assert msg_to_retry["meta"]["store_id"] == stored_msg["id"]
+            assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+        assert len(copied_msg_payload) == 0
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.PAUSED
+        assert forked_chan_retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert conditional_chan.status == BaseChannel.WAITING
+        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(forked_chan_retry_store.search(order_by="timestamp"))
+        assert len(msgs_retry_store) == 1
+        msg_retry_store = msgs_retry_store[0]
+        assert msg_retry_store["message"].meta == found_msg["message"].meta
+        assert msg_retry_store["message"].payload == found_msg["message"].payload
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("RETRY4.1 forked node OK")
+        # Retry with forked node OK: last_node raise and catch the exception,
+        # forked chan now working correctly
+        # Assert for the main chan:
+        # - the chan is already paused
+        # - The 3 yielded submessages are stored in chan retry_store
+        # - The 3 messages have to be inject in last_node or in first_node
+        # - Their payloads corresponds to element in input message's payload list
+        # Assert for the forked chan:
+        # - the chan is started
+        # - the chan retry_store is stopped
+        # - No more message in the retry store
+        forked_node.raise_exc = False
+        # First unblock the forked chan
+        self.loop.run_until_complete(forked_chan_retry_store.retry())
+        # Then relaunch other messages
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 3
+        copied_msg_payload = copy.deepcopy(msg_payload)
+        found_msg = None
+        for msg_to_retry in msgs_retry_store:
+            retry_msg_payload = msg_to_retry["message"].payload
+            copied_msg_payload.remove(retry_msg_payload)
+            nodename_where_inject = msg_to_retry["meta"]["nodename"]
+            if nodename_where_inject == first_node.name:
+                continue
+            assert nodename_where_inject == last_node.name
+            found_msg = msg_to_retry
+            assert msg_to_retry["message"].meta == stored_msg["message"].meta
+            assert msg_to_retry["meta"]["store_id"] == stored_msg["id"]
+            assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+        assert len(copied_msg_payload) == 0
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert forked_chan_retry_store.state == RetryFileMsgStore.STOPPED
+        assert conditional_chan.status == BaseChannel.WAITING
+        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(forked_chan_retry_store.search(order_by="timestamp"))
+        assert len(msgs_retry_store) == 0
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("RETRY5 last node OK")
+        # Retry with last_node OK: join_node raise and catch the exception
+        # Assert for the main chan:
+        # - the chan is already paused
+        # - Only one message in chan retry_store
+        # - The message have to be inject in join_node
+        last_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 0
+        assert chan.status == BaseChannel.WAITING
+        assert retry_store.state == RetryFileMsgStore.STOPPED
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.PROCESSED
+
+    def test_dual_msgs_n_endnodes(self):
+        """
+        Test Retry store with 2 messages, only first_node, join_node and final nodes raise exceptions
+        (that are catched)
+        first msg must be inject in first_node,
+        and second in channel start point.
+        First will not call endnodes at retry, second yes.
+
+        message.payload=["msg1", "msg2", "msg3"]
+
+        assert that:
+        - messages are processed in order by retry store
+        - only messages that have to be inject from start go to end nodes
+        - retry works with join and final nodes
+        """
+        chan, forked_chan, conditional_chan = self._create_complete_retry_chan(
+            base_chan_name="2end_retry_chan")
+        msgstore = chan.message_store
+        retry_store = chan.retry_store
+        forked_chan_retry_store = forked_chan.retry_store
+        first_node = chan.get_node("first_node")
+        forked_node = forked_chan.get_node("forked_node")
+        forked_node.raise_exc = False
+        last_node = chan.get_node("last_node")
+        last_node.raise_exc = False
+        init_node = chan.get_node("init_node")
+        init_node.raise_exc = False
+        join_node = chan.get_node("join_node")
+        drop_node = chan.get_node("drop_node")
+        drop_node.raise_exc = False
+        reject_node = chan.get_node("reject_node")
+        reject_node.raise_exc = False
+        fail_node = chan.get_node("fail_node")
+        fail_node.raise_exc = False
+        final_node = chan.get_node("final_node")
+
+        msg_payload = ["msg1", "msg2", "msg3"]
+        msg_meta = {"titi": "toto"}
+        msg1 = generate_msg(message_content=msg_payload, message_meta=msg_meta)
+        msg2 = generate_msg(message_content=msg_payload, message_meta=msg_meta)
+        chan._reset_test()
+        self.start_channels()
+
+        print("First Handle")
+        # Handle the 2 messages, the first raise a retry exception at first_node, the second
+        # is automatically put in queue at start
+        #
+        # Assert:
+        # - That the chan is in pause state
+        # - That the first message have 3 sub messages in retry store that must
+        #   be inject in first_node
+        # - That the second message is in retry store and must be inject at startpoint
+        with self.assertRaises(exceptions.PausedChanException):
+            self.loop.run_until_complete(chan.handle(msg1))
+        stored_msg1 = self.loop.run_until_complete(msgstore.get(id=msg1.uuid))
+        with self.assertRaises(exceptions.PausedChanException):
+            self.loop.run_until_complete(chan.handle(msg2))
+        stored_msg2 = self.loop.run_until_complete(msgstore.get(id=msg2.uuid))
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 4
+        assert stored_msg1["state"] == message.Message.WAIT_RETRY
+        assert stored_msg2["state"] == message.Message.WAIT_RETRY
+        copied_msg_payload = copy.deepcopy(msg_payload)
+        for msg_to_retry in msgs_retry_store:
+            store_id = msg_to_retry["meta"]["store_id"]
+            if store_id == stored_msg1["id"]:
+                retry_msg_payload = msg_to_retry["message"].payload
+                copied_msg_payload.remove(retry_msg_payload)
+                assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+                assert msg_to_retry["meta"]["nodename"] == first_node.name
+            elif store_id == stored_msg2["id"]:
+                assert msg_to_retry["message"].payload == msg_payload
+                assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+                assert msg_to_retry["meta"]["nodename"] is None
+            else:
+                raise Exception("Msg to retry store_id %s not in store", store_id)
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+
+        print("\n")
+        print("RETRY first node OK")
+        # Retry with first node OK (but endnodes KO)
+        #
+        # Assert:
+        # - That the chan is in pause state
+        # - That the 3 submessages of msg 1 passed and set the msg1 state to OK
+        # - That the second message pass in join nodes, raise a Retry exception,
+        #   is in wait_retry state and must be inject in join_node
+        first_node.raise_exc = False
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 1
+        assert msgs_retry_store[0]["message"].payload == msg_payload[-1]
+        assert msgs_retry_store[0]["message"].meta == stored_msg2["message"].meta
+        assert msgs_retry_store[0]["meta"]["store_id"] == stored_msg2["id"]
+        assert msgs_retry_store[0]["meta"]["store_chan_name"] == chan.short_name
+        assert msgs_retry_store[0]["meta"]["nodename"] == join_node.name
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert forked_chan_retry_store.state == RetryFileMsgStore.STOPPED
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg1 = self.loop.run_until_complete(msgstore.get(id=msg1.uuid))
+        stored_msg2 = self.loop.run_until_complete(msgstore.get(id=msg2.uuid))
+        assert stored_msg1["state"] == message.Message.PROCESSED
+        assert stored_msg2["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("RETRY join node OK")
+        # Retry with join_node node OK
+        #
+        # Assert:
+        # - The chan is in pause state
+        # - The second message pass join nodes, but raise a Retry exception in final_node,
+        #   is in wait_retry state and must be inject in final_node
+        join_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        print(f"{cnt_msgs_retrystore=}")
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        print(f"{msgs_retry_store=}")
+        assert cnt_msgs_retrystore == 1
+        assert msgs_retry_store[0]["message"].payload == msg_payload
+        assert msgs_retry_store[0]["message"].meta == stored_msg2["message"].meta
+        assert msgs_retry_store[0]["meta"]["store_id"] == stored_msg2["id"]
+        assert msgs_retry_store[0]["meta"]["store_chan_name"] == chan.short_name
+        assert msgs_retry_store[0]["meta"]["nodename"] == final_node.name
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert forked_chan_retry_store.state == RetryFileMsgStore.STOPPED
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg1 = self.loop.run_until_complete(msgstore.get(id=msg1.uuid))
+        stored_msg2 = self.loop.run_until_complete(msgstore.get(id=msg2.uuid))
+        print(f"{stored_msg1=}")
+        assert stored_msg1["state"] == message.Message.PROCESSED
+        assert stored_msg2["state"] == message.Message.PROCESSED
+
+        print("\n")
+        print("RETRY final node OK")
+        # Retry with final_node node OK
+        #
+        # Assert:
+        # - The chan is in WAITING state
+        # - The retry store is stopped
+        # - The second message is processed, and state is set
+        final_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        print(f"{cnt_msgs_retrystore=}")
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        print(f"{msgs_retry_store=}")
+        assert cnt_msgs_retrystore == 0
+        assert chan.status == BaseChannel.WAITING
+        assert retry_store.state == RetryFileMsgStore.STOPPED
+        assert forked_chan.status == BaseChannel.WAITING
+        assert forked_chan_retry_store.state == RetryFileMsgStore.STOPPED
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg1 = self.loop.run_until_complete(msgstore.get(id=msg1.uuid))
+        stored_msg2 = self.loop.run_until_complete(msgstore.get(id=msg2.uuid))
+        assert stored_msg1["state"] == message.Message.PROCESSED
+        assert stored_msg2["state"] == message.Message.PROCESSED
+
+    def test_rejected_in_when(self):
+        """
+        Test Retry store with 1 message, there's only one retry exception raise in the conditional subchan
+        One submessage go to the subchan
+        When the retry is done, conditional subchan raise a Rejected
+
+        message.payload=["msg1", True, "msg3"]
+
+        assert that:
+        - The conditional subchan AND the main chan are in PAUSED state
+            while the retry is not done
+        - The base message is in WAIT_RETRY
+        - Once retries are done, the base message is in Rejected status
+        """
+        chan, forked_chan, conditional_chan = self._create_complete_retry_chan(
+            base_chan_name="tstcond_retry_chan")
+        msgstore = chan.message_store
+        retry_store = chan.retry_store
+        cond_chan_retry_store = conditional_chan.retry_store
+        first_node = chan.get_node("first_node")
+        first_node.raise_exc = False
+        forked_node = forked_chan.get_node("forked_node")
+        forked_node.raise_exc = False
+        conditional_node = conditional_chan.get_node("conditional_node")
+        last_node = chan.get_node("last_node")
+        last_node.raise_exc = False
+        init_node = chan.get_node("init_node")
+        init_node.raise_exc = False
+        join_node = chan.get_node("join_node")
+        join_node.raise_exc = False
+        drop_node = chan.get_node("drop_node")
+        drop_node.raise_exc = False
+        reject_node = chan.get_node("reject_node")
+        reject_node.raise_exc = False
+        fail_node = chan.get_node("fail_node")
+        fail_node.raise_exc = False
+        final_node = chan.get_node("final_node")
+        final_node.raise_exc = False
+
+        msg_payload = ["msg1", True, "msg3"]
+        msg_meta = {"titi": "toto"}
+        msg = generate_msg(message_content=msg_payload, message_meta=msg_meta)
+        print(msg.timestamp)
+        chan._reset_test()
+        self.start_channels()
+
+        print("\n")
+        print("CHANNEL HANDLE 1")
+        # Test with the retry exception in the conditional subchan
+        # Assert:
+        # - The message is in wait_retry state
+        # - The conditional subchan is in PAUSED state
+        # - The retry store of the conditional subchan is started
+        # - The "True" submessage is in the retry store
+        with self.assertRaises(exceptions.PausedChanException):
+            self.loop.run_until_complete(chan.handle(msg))
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+        cnt_msgs_cond_retrystore = self.loop.run_until_complete(cond_chan_retry_store.count_msgs())
+        assert cnt_msgs_cond_retrystore == 1
+        msg_cond_retry_store = self.loop.run_until_complete(
+            cond_chan_retry_store.search(order_by="timestamp"))[0]
+        assert msg_cond_retry_store["message"].payload is True
+        assert msg_cond_retry_store["message"].meta == stored_msg["message"].meta
+        assert msg_cond_retry_store["meta"]["store_id"] == stored_msg["id"]
+        assert msg_cond_retry_store["meta"]["store_chan_name"] == chan.short_name
+        assert msg_cond_retry_store["meta"]["nodename"] == conditional_node.name
+        assert chan.status == BaseChannel.WAITING
+        assert retry_store.state == RetryFileMsgStore.STOPPED
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.PAUSED
+        assert cond_chan_retry_store.state == RetryFileMsgStore.RETRY_MODE
+
+        print("\n")
+        print("RETRY conditional node raise Rejected")
+        # Retry with the a Rejected instead of RetryException in the conditional subchan
+        # Assert:
+        # - The message is in REJECTED state
+        # - The conditional subchan is in WAITING state
+        # - The retry store of the conditional subchan is stopped
+        conditional_node.exc = Rejected
+        self.loop.run_until_complete(cond_chan_retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(cond_chan_retry_store.count_msgs())
+        assert cnt_msgs_retrystore == 0
+        assert chan.status == BaseChannel.WAITING
+        assert retry_store.state == RetryFileMsgStore.STOPPED
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        assert cond_chan_retry_store.state == RetryFileMsgStore.STOPPED
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.REJECTED
+
+    def test_error_in_yielded_msg(self):
+        """
+        Test Retry store with 1 message, there's only one retry exception raised
+        in the first node
+        The last_node raise an Exception
+
+        message.payload=["msg1", True, "msg3"]
+
+        assert that:
+        - The main chan is in PAUSED state while the retry is not done
+        - The base message is in WAIT_RETRY
+        - Once retries are done, the base message is in Error status
+        """
+        chan, forked_chan, conditional_chan = self._create_complete_retry_chan(
+            base_chan_name="tstcond_w_err_retry_chan")
+        msgstore = chan.message_store
+        retry_store = chan.retry_store
+        first_node = chan.get_node("first_node")
+        forked_node = forked_chan.get_node("forked_node")
+        forked_node.raise_exc = False
+        conditional_node = conditional_chan.get_node("conditional_node")
+        conditional_node.raise_exc = False
+        last_node = chan.get_node("last_node")
+        last_node.exc = Exception
+        init_node = chan.get_node("init_node")
+        init_node.raise_exc = False
+        join_node = chan.get_node("join_node")
+        join_node.raise_exc = False
+        drop_node = chan.get_node("drop_node")
+        drop_node.raise_exc = False
+        reject_node = chan.get_node("reject_node")
+        reject_node.raise_exc = False
+        fail_node = chan.get_node("fail_node")
+        fail_node.raise_exc = False
+        final_node = chan.get_node("final_node")
+        final_node.raise_exc = False
+
+        msg_payload = ["msg1", True, "msg3"]
+        msg_meta = {"titi": "toto"}
+        msg = generate_msg(message_content=msg_payload, message_meta=msg_meta)
+        chan._reset_test()
+        self.start_channels()
+
+        print("\n")
+        print("CHANNEL HANDLE 1")
+        # Test with first node that raise a retry exception
+        # Assert:
+        # - the main chan is paused
+        # - The 3 yielded submessages are stored in chan retry_store
+        # - They all have to be inject in first_node
+        # - Their payloads corresponds to element in input message's payload list
+        with self.assertRaises(exceptions.PausedChanException):
+            self.loop.run_until_complete(chan.handle(msg))
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
+        assert cnt_msgs_retrystore == 3
+        copied_msg_payload = copy.deepcopy(msg_payload)
+        for msg_to_retry in msgs_retry_store:
+            retry_msg_payload = msg_to_retry["message"].payload
+            copied_msg_payload.remove(retry_msg_payload)
+            assert msg_to_retry["message"].meta == stored_msg["message"].meta
+            assert msg_to_retry["meta"]["store_id"] == stored_msg["id"]
+            assert msg_to_retry["meta"]["store_chan_name"] == chan.short_name
+            assert msg_to_retry["meta"]["nodename"] == first_node.name
+        assert len(copied_msg_payload) == 0
+        assert chan.status == BaseChannel.PAUSED
+        assert retry_store.state == RetryFileMsgStore.RETRY_MODE
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.WAIT_RETRY
+
+        print("\n")
+        print("CHANNEL Retry")
+        # Test with all nodes OK (but last node that raise a "classic" exception)
+        # Assert:
+        # - the main chan is started
+        # - The retry store is stopped
+        # - The message state is ERROR
+        first_node.raise_exc = False
+        self.loop.run_until_complete(retry_store.retry())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        assert cnt_msgs_retrystore == 0
+        assert chan.status == BaseChannel.WAITING
+        assert retry_store.state == RetryFileMsgStore.STOPPED
+        assert forked_chan.status == BaseChannel.WAITING
+        assert conditional_chan.status == BaseChannel.WAITING
+        stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
+        assert stored_msg["state"] == message.Message.ERROR


### PR DESCRIPTION
Add a RetryStore:
- Add auto_retry_exceptions attr to nodes to catch specific exceptions that must pause the channel and store the message to replay it later
- Add a retryStore that start and stop automatically and permits inject some messages that raises for example a connectTimeout
- The retry store automatically put its channel in paused state at start, and un-pause it at stop
- A Paused channel will put all of its message in the retry store wainting for all retries done

Other changes:
- add seconds and microsecconds in FileMessageStore id to have a more granular order
- add sub message states in message meta to have the history of submessages states
- At end of a channel, the worst state of sub messages is taken as the message state

Bugs with the retry store:
- The change state doesn't work with conditional subchannels that have a message store (the base message remains in wait_retry state after a successful retry)
- end nodes are not called for the first message put in the retry store
- Different behaviour with errors in join nodes between handle and inject (if error occur in join nodes in handle, fail nodes are called, in inject it's not the case)