### PR TITLE
store and search for meta

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -162,6 +162,12 @@ class BaseChannel:
         self.sub_chan_tasks = []
         self.sub_chan_endnodes = []
 
+        # this is a dictionary that can be set/extended outside the class
+        # to influence the `to_dict` method; it is mainly relevant in extending
+        # the serialization of custom channels which are not necessarily child
+        # classes, for example with remoteadmin's `list_channels`
+        self.extra_dict = {}
+
     def _reset_sub_chan_endnodes(self, fut):
         """
         Remove all subchan callbacks from the list
@@ -864,6 +870,7 @@ class BaseChannel:
             'status': BaseChannel.status_id_to_str(self.status),
             'has_message_store': self.has_message_store,
             'processed': self.processed_msgs,
+            **self.extra_dict,
         }
 
     def subchannels(self):

--- a/pypeman/msgstore.py
+++ b/pypeman/msgstore.py
@@ -172,7 +172,7 @@ class MessageStore():
         """
 
     async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None):
+                     text=None, rtext=None, start_id=None, meta=None):
         """
         Return a list of message with store specific `id` and processed status.
 
@@ -184,8 +184,105 @@ class MessageStore():
         :param text: (optional) String to search in message content
         :param rtext: (optional) String regex to search in message content
         :param start_id: (optional): If set, start search from this id (excluded from rslt list)
+        :param meta: (optional): Search filters applied to message metadata
+
+            Message metadata are always stored as a list of strings when
+            going through `BaseNode.store_meta`. (If an in-store entry is not
+            a list, it will be handled as if a list of a single item.) If any
+            value from the inspected list of meta correspond to the query,
+            the message is selected.
+
+            In the key/value pairs of the `meta` argument to `search`,
+            keys are processed as follow:
+
+            * `text_<name>`: string to search in meta value.
+            * `rtext_<name>`: string regex to search in meta value.
+
+            * `start_<name>` / `end_<name>`: filter a range; values are
+                interpreted and compared as numbers when possible.
+
+            * `<name>`: only match with exact value.
+
+            * `order_by`: sort result by the meta indicated by value.
+
+            Reminder: when called through web API, ie from `list_msgs` in pypeman/plugins/remoteadmin/views.py
+            these keys are prefixed with "meta_", eg "meta_status" "meta_rtext_url".
+
         :return: A list of dict `{'id':<message_id>, 'state': <message_state>, 'message': <message_object>}`.
         """
+
+    @staticmethod
+    def _search_meta_filter_sort(meta: dict, result: list):
+        def isfloat(s: str):
+            """used with start_/end_"""
+            try:
+                float(s)
+                return True
+            except ValueError:
+                return False
+
+        class _FILTERS:
+            @staticmethod
+            def exact(value: str):
+                return lambda info: info == value
+
+            @staticmethod
+            def text(text: str):
+                return lambda info: text in info
+
+            @staticmethod
+            def rtext(rtext: str):
+                regex = re.compile(rtext)
+                return lambda info: regex.match(info)
+
+            @staticmethod
+            def start(start: str):
+                fstart = float(start)
+                return lambda info: isfloat(info) and float(info) < fstart
+
+            @staticmethod
+            def end(end: str):
+                fend = float(end)
+                return lambda info: isfloat(info) and float(info) > fend
+
+        # list of tuples (meta_info_name, filter_function)
+        filters: "list[tuple[str, type[bool]]]" = []
+        ordering = None
+        for key, value in meta.items():
+            if key.startswith('order_by'):
+                ordering = value
+            else:
+                filt_name, _, meta_name = key.partition('_')
+                filt = getattr(_FILTERS, filt_name, _FILTERS.exact)
+                filters.append((meta_name, filt(value)))
+
+        filtered = (
+            # For an item to be kept, ..
+            item for item in result
+            # .. it must pass all filters.
+            if all(
+                # The meta must exists, else message is filtered out.
+                meta_name in item['message'].meta
+                and (
+                    # Any info in the list may pass, one is enough.
+                    any(filt(info) for info in item['message'].meta.get[meta_name])
+                    # Info stored through `BaseNode.store_meta` are list[str] ..
+                    if isinstance(item['message'].meta.get[meta_name], list)
+                    # .. but they might not be if added through an other mean.
+                    else filt(str(item['message'].meta.get[meta_name]))
+                )
+                for meta_name, filt in filters
+            )
+        )
+
+        if ordering is None:
+            return list(filtered)
+
+        # if starting with a '-', reverse ordering
+        meta_name = ordering[ordering[0] == '-':]
+        return sorted(filtered,
+                      key=lambda item: item['message'].meta.get(meta_name),
+                      reverse=ordering[0] == '-')
 
     async def total(self):
         """
@@ -223,7 +320,7 @@ class NullMessageStore(MessageStore):
         return None
 
     async def get_message_meta_infos(self, id, meta_info_name=None):
-        return None
+        return None if meta_info_name else {}
 
     async def add_sub_message_state(self, id, sub_id, state):
         return None
@@ -270,7 +367,7 @@ class FakeMessageStore(MessageStore):
         return None
 
     async def get_message_meta_infos(self, id, meta_info_name=None):
-        return "processed"
+        return "processed" if meta_info_name else {}
 
     async def get(self, id):
         return {'id': id, 'state': 'processed', 'message': None}
@@ -340,7 +437,7 @@ class MemoryMessageStore(MessageStore):
         self.messages[id][meta_info_name] = info
 
     async def get_message_meta_infos(self, id, meta_info_name=None):
-        return self.messages[id][meta_info_name]
+        return self.messages[id][meta_info_name] if meta_info_name else self.messages[id]
 
     async def get(self, id):
         resp = dict(self.messages[id])
@@ -378,7 +475,7 @@ class MemoryMessageStore(MessageStore):
         return text in msg.payload
 
     async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None):
+                     text=None, rtext=None, start_id=None, meta=None):
         if start and start_id:
             raise ValueError("`start` and `start_id` can't both be set")
         if order_by.startswith('-'):
@@ -439,7 +536,7 @@ class MemoryMessageStore(MessageStore):
             resp = dict(value)
             resp['message'] = Message.from_dict(resp['message'])
             result.append(resp)
-        return result
+        return result if meta is None else MessageStore._search_meta_filter_sort(meta, result)
 
     async def total(self):
         return len(self.messages)
@@ -669,7 +766,7 @@ class FileMessageStore(MessageStore):
         return text in msg.payload
 
     async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None):
+                     text=None, rtext=None, start_id=None, meta=None):
         if start and start_id:
             raise ValueError("`start` and `start_id` can't both be set")
         # TODO better performance for slicing by counting file in dirs ?
@@ -758,7 +855,7 @@ class FileMessageStore(MessageStore):
                             position += 1
         if start_id and not start_id_found:
             raise IndexError("Couldn't find start_id %r in filtered results", start_id)
-        return result
+        return result if meta is None else MessageStore._search_meta_filter_sort(meta, result)
 
     async def total(self):
         return self._total

--- a/pypeman/msgstore.py
+++ b/pypeman/msgstore.py
@@ -213,6 +213,7 @@ class MessageStore():
 
     @staticmethod
     def _search_meta_filter_sort(meta_search: dict, results: list):
+        """for `meta_search`, see `meta` in the class' `search`"""
         def isfloat(s: str):
             """used with start_/end_"""
             try:

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -213,7 +213,7 @@ class BaseNode:
             '%s node end handle msg %s, result is msg %s',
             str(self), str(msg), str(result))
 
-        if not isinstance(result, types.GeneratorType) and result.store_id is not None:
+        if not isinstance(result, types.GeneratorType) and getattr(result, 'store_id', None) is not None:
             store = self.channel.message_store
             for name in self.store_meta:
                 if name in result.meta:

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -217,9 +217,9 @@ class BaseNode:
             store = self.channel.message_store
             for name in self.store_meta:
                 if name in result.meta:
-                    info_list = store.get_message_meta_infos(result.store_id, name) or []
+                    info_list = await store.get_message_meta_infos(result.store_id, name) or []
                     info_list.append(str(result.meta[name]))
-                    store.add_message_meta_infos(result.store_id, name, info_list)
+                    await store.add_message_meta_infos(result.store_id, name, info_list)
 
         if self.store_output_as:
             result.add_context(self.store_output_as, result)

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import smtplib
+import types
 import warnings
 
 from datetime import datetime
@@ -212,16 +213,16 @@ class BaseNode:
             '%s node end handle msg %s, result is msg %s',
             str(self), str(msg), str(result))
 
-        if self.store_output_as:
-            result.add_context(self.store_output_as, result)
-
-        if result.store_id:
+        if not isinstance(result, types.GeneratorType) and result.store_id is not None:
             store = self.channel.message_store
             for name in self.store_meta:
                 if name in result.meta:
                     info_list = store.get_message_meta_infos(result.store_id, name) or []
                     info_list.append(str(result.meta[name]))
                     store.add_message_meta_infos(result.store_id, name, info_list)
+
+        if self.store_output_as:
+            result.add_context(self.store_output_as, result)
 
         if self.passthrough:
             result.payload = old_msg.payload

--- a/pypeman/plugins/remoteadmin/views.py
+++ b/pypeman/plugins/remoteadmin/views.py
@@ -5,18 +5,9 @@ from aiohttp import web
 from jsonrpcserver.response import SuccessResponse
 
 from pypeman import channels
+from pypeman.channels import get_channel
 
 logger = logging.getLogger(__name__)
-
-
-def get_channel(name):
-    """
-    returns channel by name
-    """
-    for chan in channels.all_channels:
-        if name in (chan.name, chan.short_name):
-            return chan
-    return None
 
 
 async def list_channels(request, ws=None):
@@ -30,6 +21,9 @@ async def list_channels(request, ws=None):
         if chan_dict["has_message_store"]:
             chan_dict['subchannels'] = chan.subchannels()
             chans.append(chan_dict)
+        # TODO: wip
+        #if ['has_metababa']:
+        #    -NotImplemented
 
     if ws is not None:
         await ws.send_jsonrpcresp(chans)
@@ -110,10 +104,16 @@ async def list_msgs(request, ws=None):
     end_dt = args.get("end_dt", None)
     text = args.get("text", None)
     rtext = args.get("rtext", None)
+    meta = {
+        key[len('meta_'):]: value
+        for key, value in args.items()
+        if key.startswith('meta_')
+    }
+
     try:
         messages = await chan.message_store.search(
             start=start, count=count, order_by=order_by, start_dt=start_dt, end_dt=end_dt,
-            text=text, rtext=rtext, start_id=start_id) or []
+            text=text, rtext=rtext, start_id=start_id, meta=meta) or []
     except Exception:
         logger.exception("Cannot search messages")
         messages = []

--- a/pypeman/plugins/remoteadmin/views.py
+++ b/pypeman/plugins/remoteadmin/views.py
@@ -21,9 +21,6 @@ async def list_channels(request, ws=None):
         if chan_dict["has_message_store"]:
             chan_dict['subchannels'] = chan.subchannels()
             chans.append(chan_dict)
-        # TODO: wip
-        #if ['has_metababa']:
-        #    -NotImplemented
 
     if ws is not None:
         await ws.send_jsonrpcresp(chans)


### PR DESCRIPTION
* `BaseNode.store_meta`
* `MessageStore._search_meta_filter_sort`

Adds support for automatically storing metadata of handled messages: the `store_meta` parameter added to `BaseNode`'s constructor must be a set or list of keys; after a message is fully handled, if its associated `.meta` contains values for the given keys, these values are aggregated into the channel's message store. Only string values are expected and stored this way.

The stored metadata can then be used to retrieve messages through the parameter `meta` of `MessageStore.search`. The following filters are handled:
* `text_<name>`: string to search in meta value.
* `rtext_<name>`: string regex to search in meta value.
* `start_<name>` / `end_<name>`: filter a range; values are interpreted and compared as numbers when possible.
* `<name>`: only match with exact value.
* `order_by`: sort result by the meta indicated by value; leading '-' reverses.

Reminder: when called through web API, ie from `list_msgs` in `pypeman/plugins/remoteadmin/views.py` these keys are prefixed with "meta_", eg "meta_status" "meta_rtext_url".

