### PR TITLE
Refactor nodes call

### DIFF
--- a/pypeman/contrib/hl7.py
+++ b/pypeman/contrib/hl7.py
@@ -7,6 +7,8 @@ import warnings
 import hl7
 
 from pypeman import endpoints, channels, nodes, message
+from pypeman.exceptions import Dropped
+from pypeman.exceptions import Rejected
 from pypeman.errors import PypemanParamError
 
 
@@ -154,10 +156,10 @@ class MLLPChannel(channels.BaseChannel):
             await self.handle(msg)
             ack = hl7.parse(content, encoding=self.encoding)
             return str(ack.create_ack('AA')).encode(self.encoding)
-        except channels.Dropped:
+        except Dropped:
             ack = hl7.parse(content, encoding=self.encoding)
             return str(ack.create_ack('AA')).encode(self.encoding)
-        except channels.Rejected:
+        except Rejected:
             ack = hl7.parse(content, encoding=self.encoding)
             return str(ack.create_ack('AR')).encode(self.encoding)
         except Exception:

--- a/pypeman/contrib/http.py
+++ b/pypeman/contrib/http.py
@@ -8,6 +8,7 @@ import aiohttp
 from aiohttp import web
 
 from pypeman import endpoints, channels, nodes, message
+from pypeman.exceptions import Dropped
 from pypeman.errors import PypemanParamError
 
 
@@ -168,7 +169,7 @@ class HttpChannel(channels.BaseChannel):
                 status=result.meta.get('status', 200)
             )
 
-        except channels.Dropped:
+        except Dropped:
             return web.Response(body="Dropped".encode('utf-8'), status=200)
         except Exception as exc:
             logger.exception(

--- a/pypeman/exceptions.py
+++ b/pypeman/exceptions.py
@@ -1,8 +1,8 @@
 class EndChanProcess(StopAsyncIteration):
     """
-    A custom excption to tell that the channel reach the end
-    At moment, only used by conditional sub channel to avoid
-    calling nodes after him
+    A custom excption to tell that the channel reached the end
+    Currently, only used by conditional sub channel to avoid
+    calling nodes after it
     """
 
 
@@ -12,7 +12,7 @@ class Dropped(Exception):
 
 
 class Rejected(Exception):
-    """ Used to tell caller the message is invalid with a error return.
+    """ Used to tell caller the message is invalid with an error return.
     """
 
 

--- a/pypeman/exceptions.py
+++ b/pypeman/exceptions.py
@@ -1,0 +1,21 @@
+class EndChanProcess(StopAsyncIteration):
+    """
+    A custom excption to tell that the channel reach the end
+    At moment, only used by conditional sub channel to avoid
+    calling nodes after him
+    """
+
+
+class Dropped(Exception):
+    """ Used to stop process as message is processed. Default success should be returned.
+    """
+
+
+class Rejected(Exception):
+    """ Used to tell caller the message is invalid with a error return.
+    """
+
+
+class ChannelStopped(Exception):
+    """ The channel is stopped and can't process message.
+    """

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -21,8 +21,8 @@ from urllib import parse
 from concurrent.futures import ThreadPoolExecutor
 
 from pypeman.message import Message
-from pypeman.channels import Dropped
-from pypeman.channels import Rejected
+from pypeman.exceptions import Dropped
+from pypeman.exceptions import Rejected
 from pypeman.persistence import get_backend
 
 logger = logging.getLogger(__name__)

--- a/pypeman/nodes.py
+++ b/pypeman/nodes.py
@@ -6,7 +6,6 @@ import logging
 import os
 import shutil
 import smtplib
-import types
 import warnings
 
 from datetime import datetime
@@ -177,25 +176,12 @@ class BaseNode:
             '%s node end handle msg %s, result is msg %s',
             str(self), str(msg), str(result))
 
-        if self.next_node:
-            if isinstance(result, types.GeneratorType):
-                gene = result
-                result = msg  # Necessary if all nodes result are dropped
-                for res in gene:
-                    try:
-                        result = await self.next_node.handle(res)
-                    except Dropped:
-                        pass
-                    # TODO Here result is last value returned. Is it a good idea ?
-            else:
-                if self.store_output_as:
-                    result.add_context(self.store_output_as, result)
+        if self.store_output_as:
+            result.add_context(self.store_output_as, result)
 
-                if self.passthrough:
-                    result.payload = old_msg.payload
-                    result.meta = old_msg.meta
-
-                result = await self.next_node.handle(result)
+        if self.passthrough:
+            result.payload = old_msg.payload
+            result.meta = old_msg.meta
 
         return result
 

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -17,7 +17,8 @@ from pypeman import nodes
 from pypeman import events
 from pypeman import msgstore
 from pypeman import message
-from pypeman.channels import BaseChannel, Dropped, Rejected
+from pypeman.channels import BaseChannel
+from pypeman.exceptions import Dropped, Rejected
 from pypeman.errors import PypemanParamError
 from pypeman.helpers.aio_compat import awaitify
 from pypeman.test import TearDownProjectTestCase as TestCase

--- a/pypeman/tests/test_nodes.py
+++ b/pypeman/tests/test_nodes.py
@@ -13,6 +13,8 @@ import pytest
 
 from pypeman import nodes, message, conf, persistence
 
+from pypeman.exceptions import Dropped
+
 from pypeman.test import TearDownProjectTestCase as TestCase
 from pypeman.tests.common import generate_msg
 from pypeman.tests.common import LongNode
@@ -209,7 +211,7 @@ class NodesTests(TestCase):
 
         m = generate_msg(message_content='test')
 
-        with self.assertRaises(nodes.Dropped) as cm:
+        with self.assertRaises(Dropped) as cm:
             self.loop.run_until_complete(n.handle(m))
 
         self.assertEqual(str(cm.exception), msg_to_show, "Drop node message not working !")

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "click",
         "daemonlite",
         "python-dateutil",
-        "websockets",
+        "websockets<14",  # loop problem in py 3.8+
         "aiohttp",
         "jsonrpcclient",
         "jsonrpcserver<5",  # cannot import name 'Protocol' from 'typing' : fixed in py3.8


### PR DESCRIPTION
Refactor the call of node's handle (move it in channel's methods instead of nodes)

+

move all exceptions in new exceptions file

+

Change Yielder Behaviour: now if an exception occur during a yielded message, will wait the end of the yield to raise the exception (next sub-messages will be processed)