### PR TITLE
use store-related meta, not message meta

### DIFF
--- a/pypeman/tests/test_msgstore.py
+++ b/pypeman/tests/test_msgstore.py
@@ -410,7 +410,7 @@ class MsgstoreTests(TestCase):
         """Retrieve, filter and sort messages based on meta info"""
 
         results = [
-            {'id': str(k), 'message': Message(meta=meta)}  # trimmed version with only what we need
+            {'id': str(k), 'message': Message(), 'meta': meta}  # trimmed version with only what we need
             for k, meta in enumerate((
                 {
                     'one': 'one',


### PR DESCRIPTION
Search by meta was meant to search through the store-related meta (the ones that are actually used with the `BaseNode.store_meta` system). Before this it would be using the stored **message's meta** instead which for the most part likely leads to the same result. It would differ however in these scenario:
 * a message meta, which key is present in `store_meta` is removed from the message as part of the channel's processing;
 * a single message generates multiple values of a message meta (which key...) by going through eg `YielderNode`.
