### PR TITLE
msgstore revamp

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -1186,9 +1186,6 @@ class Case():
 
         self.loop = loop or asyncio.get_event_loop()
 
-        if message_store_factory is None:
-            message_store_factory = msgstore.NullMessageStoreFactory()
-
         for cond, name in zip(args, names):
             b = BaseChannel(name=name, parent_channel=parent_channel,
                             message_store_factory=message_store_factory,

--- a/pypeman/message.py
+++ b/pypeman/message.py
@@ -33,12 +33,12 @@ class Message():
     """
     # TODO : add_ctx and delete_ctx
 
+    WAIT_RETRY = "wait_retry"
     PENDING = "pending"
     PROCESSING = "processing"
-    ERROR = "error"
-    REJECTED = "rejected"
     PROCESSED = "processed"
-    WAIT_RETRY = "wait_retry"
+    REJECTED = "rejected"
+    ERROR = "error"
     # Status priority: less important first
     STATES_PRIORITY = [WAIT_RETRY, PENDING, PROCESSING, PROCESSED, REJECTED, ERROR]
 

--- a/pypeman/msgstore.py
+++ b/pypeman/msgstore.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import time
 from abc import ABC
@@ -53,6 +54,9 @@ from dateutil import parser as dateutilparser
 
 from .errors import PypemanConfigError
 from .message import Message
+
+
+logger = logging.getLogger(__name__)
 
 
 class MessageStoreFactory(ABC):
@@ -975,7 +979,10 @@ class FileMessageStoreFactory(MessageStoreFactory):
                     child.unlink()
             path.rmdir()
 
-        rmrf(store.base_path)
+        if store.base_path.exists():
+            rmrf(store.base_path)
+        else:
+            logger.warning(f"deleting file message store that was not started: {self.base_path!r}")
 
 
 class FileMessageStore(MessageStore):

--- a/pypeman/msgstore.py
+++ b/pypeman/msgstore.py
@@ -1,77 +1,388 @@
-import datetime
-import dateutil.parser
+"""Message store interface specification and shipped implementations.
+
+Every instantiated channel (:class:`pypeman.BaseChannel`) may be
+associated a message store :class:`MessageStore`.
+
+A message store provides the ability to store and restore
+a :class:`pypeman.Message` as well as a store-related meta (distinct
+from the message's meta). Once a message is stored, it can be referred
+to through a specific id (also distinct from the message's UUID).
+
+Stores should not be created directly; the factory pattern should be
+used instead. In a pypeman project is usually a unique message store
+factory. The following ones are provided, differing only by there
+backing storage:
+    * :class:`NullMessageStoreFactory`,
+    * :class:`MemoryMessageStoreFactory`,
+    * :class:`FileMessageStoreFactory`.
+
+At channel level, a store is associated at creation by handing it the
+factory. Every new message passing through the channel's
+:meth:`BaseChannel.handle` method will be stored (ie. some time before
+calling any node's :meth:`BaseNode.process`).
+
+The message store is also involved in the :attr:`BaseNode.store_meta`
+mechanism (store declared meta of passing-by messages after processing).
+
+A channel associated with a message store will enable replaying
+a message through :meth:`BaseChannel.replay`. The
+:class:`pypeman.plugins.remoteadmin.RemoteAdminPlugin` plugin provides
+a more hands-on access to it on a running pypeman project.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import json
-import logging
-import os
 import re
 import time
-
-from itertools import islice
-from collections import OrderedDict
+from abc import ABC
+from abc import abstractmethod
+from copy import deepcopy
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
+from pathlib import PurePath
+from typing import Any
+from typing import Callable
+from typing import Literal
+from typing import TypedDict
 
-from pypeman.message import Message
+from dateutil import parser as dateutilparser
 
-from pypeman.errors import PypemanConfigError
-
-logger = logging.getLogger("pypeman.store")
-
-DATE_FORMAT = '%Y%m%d_%H%M%S%f'
+from .errors import PypemanConfigError
+from .message import Message
 
 
-class MessageStoreFactory():
-    """ Message store factory class can generate Message store instance for specific store_id. """
+class MessageStoreFactory(ABC):
+    """A :class:`MessageStoreFactory` instance can generate related
+    :class:`MessageStore` instances for a specific `store_id`. The
+    later in turn is needed to store :class:`Message`s.
 
-    def get_store(self, store_id):
+    Note for implementing classes: the constructor is expected to do
+    precisely nothing, that is no new dir/file on fs or table in db...
+
+    :abstract:
+    """
+
+    def __init__(self):
+        self._stores: dict[str, MessageStore] = {}
+
+    @abstractmethod
+    def _new_store(self, store_id: str) -> MessageStore:
+        """(implementation) Create a new store refered to as `store_id`.
+
+        Note for implementing classes: this function doesn't perform
+        any heavy work (not async), instead the returned store's
+        :meth:`MessageStore.start` does.
+
+        :param store_id: Identifier of the corresponding message store.
+        :return: New :class:`MessageStore` instance.
         """
-        :param store_id: identifier of corresponding message store.
-        :return: A MessageStore corresponding to correct store_id.
+
+    @abstractmethod
+    async def _delete_store(self, store: MessageStore):
+        """(implementation) Wipe out the store.
+
+        Note to implementing classes: the store might not have been
+        started :meth:`MessageStore.start`, and there is no logic
+        calling :meth:`delete` on all the stored messages.
+
+        :param store: Store instanciated by this very class.
         """
 
+    def get_store(self, store_id: str) -> MessageStore:
+        """Return a store corresponding to the given `store_id`.
 
-class MessageStore():
-    """ A MessageStore keep an history of processed messages. Mainly used in channels. """
+        :param store_id: Identifier of the corresponding message store.
+        :return: New or existing :class:`MessageStore` instance.
+        """
+        existing = self._stores.get(store_id)
+        return existing or self._stores.setdefault(store_id, self._new_store(store_id))
+
+    def list_store(self) -> list[str]:
+        """List of instanciated stores' `store_id`.
+
+        :return: List.
+        """
+        return list(self._stores.keys())
+
+    async def delete_store(self, store_id: str):
+        """Delete the whole store and everything associated with it.
+
+        Really only meant to be used in testing.
+        !CAUTION! this cannot be undone.
+
+        This is a method on the factory and not on the store for book
+        keeping reasons.
+
+        :raise KeyError: When the `store_id` does not exist.
+        """
+        existing = self._stores.pop(store_id)
+        await self._delete_store(existing)
+        # private usage in friend class
+        existing._cached_total = 0
+
+
+class MessageStore(ABC):
+    """A :class:`MessageStore` keep an history of processed messages.
+
+    Stored messages are associated a unique `id`. The storage mechanism
+    is implementation defined but enables retrieving the object
+    :class:`Message` as it was stored.
+
+    `id`s *must* be considered opaque types. They are guaranteed to be
+    :class:`str` for ease of manipulation, but content *should not*
+    be interpreted.
+
+    Alongside each message is a store-related meta dict. (It is not
+    related to the message's actual meta dict.)
+
+    It provides the following main methods:
+        * :meth:`start`
+        * :meth:`store`
+        * :meth:`delete`
+        * :meth:`total`
+        * :meth:`get`
+        * :meth:`search`
+
+    A valid deriving class must at least provide implementation for:
+        * :meth:`_store`
+        * :meth:`_delete`
+        * :meth:`_total`
+        * :meth:`_get_message`
+        * :meth:`_get_storemeta`
+        * :meth:`_set_storemeta`
+        * :meth:`_span_select`
+
+    It may also override:
+        * :meth:`_start` -- default is no-op
+        * :meth:`get_many` -- default might be inefficient
+
+    :abstract:
+    """
+
+    class StoredEntry_(TypedDict):
+        """Data format used when retrieving messages."""
+
+        id: str  # store-dependant id, different from message.uuid
+        meta: dict[str, Any]  # store-related meta, different from message.meta
+        # TODO: ideally this `Any` would be replaced with `list[str]` with explicit checks at access points
+        message: Message
+        state: Message.State_  # TODO: remove in favor of _['meta']['state']
+
+    async def _start(self):
+        """(implementation) Called at startup to initialize the store.
+
+        This method is not marked as abstract and thus not required.
+        """
+
+    @abstractmethod
+    async def _store(self, msg: Message, ini_meta: dict[str, Any]) -> str:
+        """(implementation) Store a message.
+
+        Implementation must ensure that all operations with an id
+        obtained this way are valid until a matching :meth:`_delete`.
+
+        An exact same message (same uuid) should not be stored twice;
+        the implementation may raise an error if it detects such.
+
+        :param msg: Message to be stored.
+        :param ini_meta: Store-related initial meta.
+        :return: Store-dependant id.
+        :raise ValueError: When a double-store (same uuid) is detected.
+        """
+
+    @abstractmethod
+    async def _delete(self, id: str):
+        """(implementation) Delete a stored message.
+
+        After this operation, the id must be considered invalid.
+        The implementation is free to reuse ids.
+
+        :param id: Store-dependant id.
+        :raise LookupError: When the id does not name a stored message.
+        """
+
+    @abstractmethod
+    async def _total(self) -> int:
+        """(implementation) Compute, without caching, the number of
+        messages stored at this time.
+
+        :return: Total Stored message count.
+        """
+
+    @abstractmethod
+    async def _get_message(self, id: str) -> Message:
+        """(implementation) Retrieve a stored message.
+
+        :param id: Store-dependant id.
+        :return: Message as it was stored.
+        :raise LookupError: When the id does not name a stored message.
+        """
+
+    @abstractmethod
+    async def _get_storemeta(self, id: str) -> dict[str, Any]:
+        """(implementation) Retrieve the store-related meta.
+
+        Note to implementing classes: this operation is considered
+        cheaper than :meth:`_get_message`.
+
+        :param id: Store-dependant id.
+        :return: Store-related meta dict.
+        :raise LookupError: When the id does not name a stored message.
+        """
+
+    @abstractmethod
+    async def _set_storemeta(self, id: str, meta: dict[str, Any]):
+        """(implementation) Replace the store-related meta.
+
+        :param id: Store-dependant id.
+        :return: Message as it was stored.
+        :raise LookupError: When the id does not name a stored message.
+        """
+
+    @abstractmethod
+    async def _span_select(self, start_dt: datetime | None, end_dt: datetime | None) -> list[str]:
+        """(implementation) Gather the ids for messages that fall
+        within the given time frame.
+
+        These must be sorted by (increasing) timestamps.
+
+        Note for implementing classes: `start_dt < end_dt` is
+        verified, as well as `self.total() != 0`. However either or
+        both datetimes given may be completely out of the range of
+        stored entries.
+
+        :param start_dt: (optional) Inclusive lower bound, or None.
+        :param end_dt: (optional) Exclusive upper bound, or None.
+        """
 
     async def start(self):
-        """
-        Called at startup to initialize store.
-        """
+        """Called at startup to initialize the store."""
+        await self._start()
+        self._cached_total = await self._total()
 
-    async def store(self, msg):
-        """
-        Store a message in the store.
+    async def store(self, msg: Message) -> str:
+        """Store a message in the store.
 
-        :param msg: The message to store.
+        Its state is right away initialized to :obj:`Message.PENDING`.
+
+        An exact same message (same uuid) should not be stored twice.
+
+        :param msg: Message to store.
         :return: Id for this specific message.
+        :raise ValueError: When a double-store (same uuid) is detected.
         """
+        id = await self._store(msg, {"state": Message.PENDING})
+        self._cached_total += 1
+        return id
 
-    async def add_message_meta_infos(self, id, meta_info_name, info):
+    async def delete(self, id: str):
+        """Delete a message in the store corresponding to the given id.
+
+        Useful for tests and (maybe in the future) for cleanup.
+        !CAUTION! this cannot be undone.
+
+        :param id: Store-dependant id.
+        :return: Same as :meth:`get`. This will be removed.
+        :raise LookupError: When the id does not name a stored message.
         """
-        Add message meta infos in the store
+        # TODO: don't, unnecessary
+        entry = await self.get(id)
+        await self._delete(id)
+        self._cached_total -= 1
+        return entry
 
-        :param id: Message specific store id.
-        :param meta_info_name: The name of the meta info to create/update
-        :param info: The info value
+    # TODO: this is not async anymore, marking it non-async shows it is a cheap operation
+    async def total(self) -> int:
+        """Number of messages stored at this time.
+
+        Marked async but will no longer be at some point.
+
+        :return: Total Stored message count.
         """
+        return self._cached_total
 
-    async def get_message_meta_infos(self, id, meta_info_name=None):
+    async def get(self, id: str) -> StoredEntry_:
+        """Retrieve a store entry.
+
+        :param id: Store-dependant id.
+        :return: Message store entry, with the message as it was
+            stored and a store-related meta dict.
+        :raise LookupError: When the id does not name a stored message.
         """
-        Get message meta infos in the store
+        meta = await self._get_storemeta(id)
+        return {
+            "id": id,
+            "meta": meta,
+            "message": await self._get_message(id),
+            "state": meta["state"],  # TODO: phase out/remove
+        }
 
-        :param id: Message specific store id.
-        :param meta_info_name: (optional) The name of the meta info to get,
-            if not set returns the entire dict
+    async def get_many(self, ids: list[str]) -> list[StoredEntry_]:
+        """Retrieve multiple store entries at once.
+
+        This method does not expect being used to retrieve a single
+        entry; see :meth:`get` instead.
+
+        Some implementation may override this method to be more
+        efficient than repeatedly calling :meth:`get` in a loop.
+        (Which is more or less what this default implementation does.)
+
+        Note for implementing classes: `1 < len(ids)` is verified, as
+        well as `self.total() != 0`.
+
+        :param ids: Sequence of store-dependant id.
+        :return: The sequence of store entries.
+        :raise LookupError: When an id does not name a stored message.
         """
+        return await asyncio.gather(*map(self.get, ids))
 
-    async def change_message_state(self, id, new_state):
+    async def add_message_meta_infos(self, id: str, meta_info_name: str, info: Any):
+        """Add a store-related meta info to a message.
+
+        :param id: Store-dependant id.
+        :param meta_info_name: Name of the meta info to create/update.
+        :param info: Info value.
+        :raise LookupError: When the id does not name a stored message.
         """
-        Change the `id` message state.
+        meta = await self._get_storemeta(id)
+        meta[meta_info_name] = info
+        await self._set_storemeta(id, meta)
 
-        :param id: Message specific store id.
-        :param new_state: Target state.
+    async def get_message_meta_infos(self, id: str, meta_info_name: str | None = None) -> Any | None:
+        """Get a store-related meta info for a message.
+
+        :param id: Store-dependant id.
+        :param meta_info_name: (optional) Name of the meta info to
+            retrieve. If `None`, the whole dict is returned.
+        :raise LookupError: When the id does not name a stored message.
         """
+        meta = await self._get_storemeta(id)
+        return meta if meta_info_name is None else meta.get(meta_info_name)
 
-    async def add_sub_message_state(self, id, sub_id, state):
+    async def get_message_state(self, id: str) -> Message.State_:
+        """Get a message's state. Shorthand for
+        :meth:`get_message_meta_infos` with `"state"`
+
+        :param id: Store-dependant id.
+        :raise LookupError: When the id does not name a stored message.
+        """
+        return await self.get_message_meta_infos(id, "state")
+
+    async def change_message_state(self, id: str, new_state: Message.State_):
+        """Change a message's state. Shorthand for
+        :meth:`add_message_meta_infos` with `"state"`
+
+        :param id: Store-dependant id.
+        :param new_state: ye.
+        :raise LookupError: When the id does not name a stored message.
+        """
+        await self.add_message_meta_infos(id, "state", new_state)
+
+    async def add_sub_message_state(self, id: str, sub_id: str, state: str):
         """
         Add a state to the meta 'submessages_state_history" of a message
         submessages_state_history meta is a list of dicts of this form:
@@ -82,14 +393,11 @@ class MessageStore():
         }
 
         :param id: Message specific store id.
-        :param sub_id: The sub message's id (could be the same as the id)
+        :param sub_id: The sub message's id (could be the same as the id).
         :param state: Target state.
         """
         try:
-            submessages_state_history = await self.get_message_meta_infos(
-                id=id,
-                meta_info_name="submessages_state_history"
-            )
+            submessages_state_history = await self.get_message_meta_infos(id, "submessages_state_history")
             if submessages_state_history is None:
                 submessages_state_history = []
         except KeyError:
@@ -101,24 +409,17 @@ class MessageStore():
                 "timestamp": time.time(),
             }
         )
-        await self.add_message_meta_infos(
-            id=id,
-            meta_info_name="submessages_state_history",
-            info=submessages_state_history,
-        )
+        await self.add_message_meta_infos(id, "submessages_state_history", submessages_state_history)
 
-    async def set_state_to_worst_sub_state(self, id):
+    async def set_state_to_worst_sub_state(self, id: str):
         """
         Change the `id` message state to the worst state stored in submessages_state_history
 
         :param id: Message specific store id.
         """
         try:
-            submessages_state_history = await self.get_message_meta_infos(
-                id=id,
-                meta_info_name="submessages_state_history"
-            )
-        except KeyError:
+            submessages_state_history = await self.get_message_meta_infos(id, "submessages_state_history")
+        except LookupError:
             submessages_state_history = []
         if not submessages_state_history:
             raise IndexError("No sub message state stored, cannot choose the worst")
@@ -127,758 +428,734 @@ class MessageStore():
             state = submsg_info["state"]
             if Message.STATES_PRIORITY.index(worst_state) < Message.STATES_PRIORITY.index(state):
                 worst_state = state
-        await self.change_message_state(id=id, new_state=worst_state)
+        await self.change_message_state(id, worst_state)
 
-    async def get(self, id):
+    async def get_preview_str(self, id: str) -> Message:
+        """A deprecated weirdness which absolutely does not return str.
+
+        Retrieve a message by id, then craft a fake message with
+        for payload the first 1000 characters of a textual
+        representation of the actual message's payload.
+
+        TODO: remove it, or rework it; it should return a str.
+
+        :param id: Store-dependant id.
+        :raise LookupError: When the id does not name a stored message.
+        :return: go figure.
         """
-        Return one message corresponding to given `id` with his status.
+        msg = await self.get_msg_content(id)
+        try:
+            msg.payload = str(msg.payload)[:1000]
+        # rational for the pragma: this code was ported over 1:1 from ol' msgstore;
+        # in python no object throws on `str()` unless done intentionally in `__str__`,
+        # which nobody does or should even think about doing (keep in mind that
+        # `__repr__` could too.. so does literally anything actually)
+        except Exception:  # pragma: no cover
+            msg.payload = repr(msg.payload)[:1000]
+        return msg
 
-        :param id: Message id. Message store dependant.
-        :return: A dict `{'id':<message_id>, 'state': <message_state>, 'message': <message_object>}`.
+    async def get_msg_content(self, id: str) -> Message:
+        """Deprecated shorthand for :meth:`get` + `result['message']`.
+
+        TODO: remove it.
+
+        :param id: Store-dependant id.
+        :raise LookupError: When the id does not name a stored message.
+        :return: go figure.
         """
+        return await self._get_message(id)
 
-    async def get_preview_str(self, id):
+    async def get_payload_str(self, id: str) -> str:
+        """Shorthand to get a representation of the message's payload.
+
+        Essentially equivalent to using :func:`str` with the
+        `['message'].payload` obtained with :meth:`get`.
+
+        :param id: Store-dependant id.
+        :raise LookupError: When the id does not name a stored message.
+        :return: Textual representation of the payload.
         """
-        Return the first 1000 chars of message content corresponding to `id`
+        return str((await self._get_message(id)).payload)
 
-        :param id: Message id. Message store dependant.
-        :return: A dict `{'id':<message_id>, 'message_content': str}`.
+    async def is_regex_in_msg(self, id: str, rtext: str | re.Pattern[str]):
+        """Shorthand pattern check `rtext` in :meth:`get_payload_str`.
+
+        :param id: Store-dependant id.
+        :param rtext: String or regular expression.
+        :return: True if it matches False otherwise.
         """
+        return re.search(rtext, await self.get_payload_str(id)) is not None
 
-    async def get_msg_content(self, id):
+    async def is_txt_in_msg(self, id: str, text: str):
+        """Shorthand to check if `text` is in :meth:`get_payload_str`.
+
+        :param id: Store-dependant id.
+        :param text: String or regular expression.
+        :return: True if it matches False otherwise.
         """
-        Return the content of the message corresponding to given `id`
+        return text in await self.get_payload_str(id)
 
-        :param id: Message id. Message store dependant.
-        :return: A dict `{'id':<message_id>, 'message_content': Message}`.
-        """
+    async def search(
+        self,
+        count: int = 10,
+        start_id: str | None = None,
+        order_by: Literal["timestamp", "state", "-timestamp", "-state"] | str = "timestamp",
+        group_by: Literal["state"] | str | None = None,
+        start_dt: datetime | str | None = None,
+        end_dt: datetime | str | None = None,
+        text: str | None = None,
+        rtext: str | None = None,
+        meta: dict[str, str] | None = None,
+    ) -> list[StoredEntry_] | dict[str, list[StoredEntry_]]:
+        """Fetch a list of message entries according to specification.
 
-    async def is_regex_in_msg(self, id, rtext):
-        """
-        Return True if the str(msg) contains the regex rtext
+        :param count: Number of entries to return. This is a maximum:
+            result might consist of fewer matches. `count` only applies
+            time-wise, that is it will result in the `count` first (or
+            last if `order_by` is reversed) messages (within the time
+            span `start_dt`..`end_dt`).
+        :param start_id: (optional): If set, start search from this id
+            (excluded from result).
 
-        :param id: Message id. Message store dependant.
-        :param rtext: string of regular expression to search in msg
-        :return: True if it matches False otherwise
-        """
+        :param order_by: Sort results by a key. If the key starts with
+            '-' the ordering is reversed. Default: 'timestamp', allowed
+            values: ['timestamp', 'state', 'meta_<name>'].
+        :param group_by: Group the results by a key. Instead of a list,
+            the result will be a dict that maps from the various values
+            found for the key to a list of matching entries. Value like
+            'meta_<name>' may be used to group by meta.
 
-    async def is_txt_in_msg(self, id, text):
-        """
-        Return True if the str(msg) contains param text
+        :param start_dt: (optional) Limit to messages since this time.
+        :param end_dt: (optional) Limit to messages until this time.
+        :param text: (optional) Text to search in message content.
+        :param rtext: (optional) Pattern to search in message content.
+        :param meta: (optional): Meta search options (see full doc).
 
-        :param id: Message id. Message store dependant.
-        :param text: String. The text to search in msg
-        :return: True if it text is found, False otherwise
-        """
-
-    async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None, meta=None):
-        """
-        Return a list of message with store specific `id` and processed status.
-
-        :param start: (DEPRECATED: use start_id instead) First element.
-        :param count: Count of elements since first element.
-        :param order_by: Message order. Allowed values : ['timestamp', 'status'].
-        :param start_dt: (optional) Isoformat start date(time) to filter with
-        :param end_dt: (optional) Isoformat end date(time) to filter with
-        :param text: (optional) String to search in message content
-        :param rtext: (optional) String regex to search in message content
-        :param start_id: (optional): If set, start search from this id (excluded from rslt list)
-        :param meta: (optional): Search filters applied to message metadata
-
-            Message metadata are always stored as a list of strings when
-            going through `BaseNode.store_meta`. (If an in-store entry is not
-            a list, it will be handled as if a list of a single item.) If any
-            value from the inspected list of meta correspond to the query,
-            the message is selected.
+            Message meta are always stored as a list of strings when
+            going through `BaseNode.store_meta`. (If an in-store entry
+            is not a list, it will be handled as if a list of a single
+            item.) If any value from the inspected list of meta
+            correspond to the query, the message is selected.
 
             In the key/value pairs of the `meta` argument to `search`,
             keys are processed as follow:
 
-            * `text_<name>`: string to search in meta value.
-            * `rtext_<name>`: string regex to search in meta value.
+            * `exact_<name>`: only match with exact value;
 
-            * `start_<name>` / `end_<name>`: filter a range; values are
-                interpreted and compared as numbers when possible.
+            * `text_<name>`: string to search in meta value;
+            * `rtext_<name>`: string regex to search in meta value;
 
-            * `<name>`: only match with exact value.
+            * `start_<name>` / `end_<name>`: filter a range, values are
+                interpreted and compared as numbers when possible;
 
-            * `order_by`: sort result by the meta indicated by value.
+            Reminder: when called through web API, ie from `list_msgs`
+            in pypeman/plugins/remoteadmin/views.py, these keys, in the
+            request params, are prefixed with "meta_" (eg.
+            "meta_state" "meta_rtext_url") but here they no longer are.
 
-            Reminder: when called through web API, ie from `list_msgs` in pypeman/plugins/remoteadmin/views.py
-            these keys are prefixed with "meta_", eg "meta_status" "meta_rtext_url".
-
-        :return: A list of dict `{'id':<message_id>, 'state': <message_state>, 'message': <message_object>}`.
+        :return: List of fitting message entries or, if `group_by` is
+            given, dict of group to list of fitting message entries.
         """
+        # early dum check (as per contract, don't call _span_select in this case)
+        if 0 == await self.total():
+            return [] if group_by is None else {}
+
+        # TODO: phase out the 'str' option, this should be caller responsibility
+        if isinstance(start_dt, str):
+            start_dt = dateutilparser.isoparse(start_dt)
+        if isinstance(end_dt, str):
+            end_dt = dateutilparser.isoparse(end_dt)
+
+        if start_dt and end_dt:
+            assert start_dt <= end_dt, "backward time span given"
+            assert start_dt != end_dt, "empty time span given"
+
+        # only one of the two is non-none at once
+        order_by_payload = None
+        order_by_meta = None
+        reverse = "-" == order_by[0]
+        if reverse:
+            order_by = order_by[1:]
+        if order_by.startswith("meta_"):
+            order_by_meta = order_by[5:]
+        else:
+            assert order_by in {"timestamp", "state"}
+            order_by_payload: ... = order_by
+
+        # only one of the two may be non-none at once
+        group_by_payload = None
+        group_by_meta = None
+        if group_by:
+            if group_by.startswith("meta_"):
+                group_by_meta = group_by[5:]
+            else:
+                assert group_by in {"state"}
+                group_by_payload: ... = group_by
+
+        # note that it compiles any rtext and already raises if invalid
+        payload_filt = _MsgFilt(order_by_payload, group_by_payload, text, rtext)
+        meta_filt = _MetaFilt(order_by_meta, group_by_meta, meta)
+
+        span = await self._span_select(start_dt, end_dt)
+        if reverse:
+            span.reverse()
+        if start_id:
+            # +1: excluding start id; note that this already raises if `start_id` is not in
+            cut = span.index(start_id) + 1
+            span = span[cut:]
+
+        filtered: list[MessageStore.StoredEntry_] = []
+
+        needed = count
+        span_len = len(span)
+        scan_head = 0
+        # continuously grab however-many messages needed, filter and append
+        # until fulfilled (0 == needed) or exhausted (scan_head >= span_len)
+        while needed and scan_head < span_len:
+            available = span_len - scan_head
+            grab = min(needed, available)
+
+            scan_ahead = scan_head + grab
+            chunk = (
+                [await self.get(span[0])]
+                if 1 == grab  # as per `get_many`'s contract
+                else await self.get_many(span[scan_head:scan_ahead])
+            )
+            filtered.extend(it for it in chunk if payload_filt.filter(it) and meta_filt.filter(it))
+
+            needed = count - len(filtered)
+            scan_head = scan_ahead
+
+        # a word to (whoever) when :param:`order_by` is by timestamp,
+        # ie `order_by_payload == "timestamp"`, `filtered` will always
+        # be already sorted...
+        order = meta_filt.order if order_by_meta else payload_filt.order
+        filtered.sort(key=order, reverse=reverse)
+        if not group_by:
+            return filtered
+
+        group = meta_filt.group if group_by_meta else payload_filt.group
+        grouped: dict[str, list[MessageStore.StoredEntry_]] = {}
+        for it in filtered:
+            # at this point filtered is also sorted, so each individual group will be too
+            grouped.setdefault(group(it), []).append(it)
+        return grouped
+
+
+class _MsgFilt:
+    """(internal) see :meth:`MessageStore.sort`
+
+    used to filter/order/group entries by there message's payload
+    """
+
+    def __init__(
+        self,
+        order_by: Literal["timestamp", "state"] | None,
+        group_by: Literal["state"] | None,
+        text: str | None,
+        rtext: str | None,
+    ):
+        # `self.order()` (resp. `self.group()`) are never called
+        # if `order_by` (resp. `group_by`) is None
+        self.order_by = order_by
+        self.group_by = group_by
+        self.text = text
+        self.regex = re.compile(rtext) if rtext else None
+        # no filter, will always return True
+        self.nofilt = not self.text and not self.regex
+
+    def filter(self, entry: MessageStore.StoredEntry_) -> bool:
+        ":return: true if the entry is to be kept in the result"
+        if self.nofilt:
+            return True
+        astr = str(entry["message"].payload)
+        if self.text and self.text not in astr:
+            return False
+        if self.regex and self.regex.search(astr) is None:
+            return False
+        return True
+
+    def order(self, entry: MessageStore.StoredEntry_) -> Any:
+        """:return: SupportsRichComparison (see usage)"""
+        if "timestamp" == self.order_by:
+            return entry["message"].timestamp
+        if "state" == self.order_by:
+            return entry["meta"]["state"]
+        assert None, "unreachable"  # pragma: no cover
+
+    def group(self, entry: MessageStore.StoredEntry_) -> str:
+        ":return: group name for entry"
+        if "state" == self.group_by:
+            return entry["meta"]["state"]
+        assert None, "unreachable"  # pragma: no cover
+
+
+class _MetaFilt:
+    """(internal) see :meth:`MessageStore.sort`
+
+    used to filter/order/group entries by there store-related meta
+
+    remark: in constructor params, `order_by` and `group_by` are
+    without the leading 'meta_'
+    """
 
     @staticmethod
-    def _search_meta_filter_sort(meta_search: dict, results: list):
-        """for `meta_search`, see `meta` in the class' `search`"""
-        def isfloat(s: str):
-            """used with start_/end_"""
-            try:
-                float(s)
-                return True
-            except ValueError:
-                return False
+    def _isfloat(s: str):
+        """used with start_/end_"""
+        try:
+            float(s)
+            return True
+        except ValueError:
+            return False
 
-        class _FILTERS:
-            @staticmethod
-            def exact(value: str):
-                return lambda info: info == value
+    class _FILTERS:
+        @staticmethod
+        def exact(value: str) -> Callable[[str], bool]:
+            return lambda info: info == value
 
-            @staticmethod
-            def text(text: str):
-                return lambda info: text in info
+        @staticmethod
+        def text(text: str) -> Callable[[str], bool]:
+            return lambda info: text in info
 
-            @staticmethod
-            def rtext(rtext: str):
-                regex = re.compile(rtext)
-                return lambda info: bool(regex.search(info))
+        @staticmethod
+        def rtext(rtext: str) -> Callable[[str], bool]:
+            regex = re.compile(rtext)
+            return lambda info: bool(regex.search(info))
 
-            @staticmethod
-            def start(start: str):
-                fstart = float(start)
-                return lambda info: isfloat(info) and float(info) >= fstart
+        @staticmethod
+        def start(start: str) -> Callable[[str], bool]:
+            fstart = float(start)
+            return lambda info: _MetaFilt._isfloat(info) and float(info) >= fstart
 
-            @staticmethod
-            def end(end: str):
-                fend = float(end)
-                return lambda info: isfloat(info) and float(info) <= fend
+        @staticmethod
+        def end(end: str) -> Callable[[str], bool]:
+            fend = float(end)
+            return lambda info: _MetaFilt._isfloat(info) and float(info) <= fend
 
-        # list of tuples (meta_info_name, filter_function)
-        filters: "list[tuple[str, type[bool]]]" = []
-        ordering = None
-        for key, value in meta_search.items():
-            if key.startswith('order_by'):
-                ordering = value
-            else:
-                filt_name, _, meta_name = key.partition('_')
-                filt = getattr(_FILTERS, filt_name, _FILTERS.exact)
-                filters.append((meta_name, filt(value)))
+    def __init__(self, order_by: str | None, group_by: str | None, meta: dict[str, str] | None):
+        # `self.order()` (resp. `self.group()`) are never called
+        # if `order_by` (resp. `group_by`) is None
+        # `str()` is for typing reason so that it's a non-none str when used
+        self.order_by = str(order_by)
+        self.group_by = str(group_by)
+        # each key is a `meta_info_name`, and each value is a list of filter functions
+        self.filters: dict[str, list[Callable[[str], bool]]] = {}
+        if meta:
+            for key, value in meta.items():
+                filt_name, _, meta_name = key.partition("_")
+                filt = getattr(_MetaFilt._FILTERS, filt_name)
+                self.filters.setdefault(meta_name, []).append(filt(value))
 
-        filtered = (
-            # For an item to be kept, ..
-            item for item in results
-            # .. it must pass all filters.
-            if all(
-                # The meta must exists, else message is filtered out.
-                meta_name in item['message'].meta
-                and (
-                    # Any info in the list may pass, one is enough.
-                    any(filt(info) for info in item['message'].meta[meta_name])
-                    # Info stored through `BaseNode.store_meta` are list[str] ..
-                    if isinstance(item['message'].meta[meta_name], list)
-                    # .. but they might not be if added through an other mean.
-                    else filt(str(item['message'].meta[meta_name]))
-                )
-                for meta_name, filt in filters
-            )
-        )
+    def filter(self, entry: MessageStore.StoredEntry_) -> bool:
+        """:return: true if the entry is to be kept in the result
 
-        if ordering is None:
-            return list(filtered)
-
-        def key(item):
-            info = item['message'].meta.get(meta_name)
-            if not info:  # None, empty list, missing, ..
-                return ""
-            return str(info[0] if isinstance(info, list) else info)
-
-        # if starting with a '-', reverse ordering, the meta_name is the rest
-        meta_name = ordering[ordering[0] == '-':]
-        return sorted(filtered, key=key, reverse=ordering[0] == '-')
-
-    async def total(self):
+        every filter on meta must match, but on any info of the meta
         """
-        :return: total count of messages
+        meta = entry["meta"]
+        # note that no filter will return True as expected
+        for name, filts in self.filters.items():
+            m = meta.get(name, [])
+            info: list[Any] = m if isinstance(m, list) else [m]
+            for filt in filts:  # .                        for each filter for this meta info,
+                if not any(filt(str(i)) for i in info):  # if none of the values matche
+                    return False  # .                      then stop here
+            # the lines above are roughly equivalent to:
+            # ( filts[0](info[0]) OR filts[0](info[1]) OR .. ) AND ( filts[1](info[0]) OR .. ) AND ..
+        return True
+
+    def order(self, entry: MessageStore.StoredEntry_) -> Any:
+        """:return: :class:`str` of the meta
+
+        uses the first value if the meta is a list
+        for an empty list will use an empty string
+        same if this meta is not present
         """
+        m = entry["meta"].get(self.order_by, [])
+        info: list[Any] = m if isinstance(m, list) else [m]
+        return str(info[0]) if info else ""
 
-    async def delete(self, id):
+    def group(self, entry: MessageStore.StoredEntry_) -> str:
+        """:return: group name for entry
+
+        uses the first value if the meta is a list
+        for an empty list will use an empty string
+        same if this meta is not present
+
+        TODO(potential evolution): if deemed interesting,
+            messages could be present in multiple groups
         """
-        Delete one message in the store corresponding to given `id` with his status.
-        Useful for tests and maybe in the future to permits cleanup of message store
-
-        !CAUTION! : cannot be undone
-
-        :param id: Message id. Message store dependant.
-        :return: A dict `{'id':<message_id>, 'state': <message_state>, 'message': <message_object>}`.
-        """
+        m = entry["meta"].get(self.group_by, [])
+        info: list[Any] = m if isinstance(m, list) else [m]
+        return str(info[0]) if info else ""
 
 
-class NullMessageStoreFactory(MessageStoreFactory):
-    """ Return an NullMessageStore that do nothing at all. """
-    def get_store(self, store_id):
+class NullMessageStoreFactory(MessageStoreFactory):  # pragma: no cover
+    """A no-op message store.
+
+    Always successful, nothing is stored. I don't know what that
+    implies, it's scary, but it's needed.
+
+    That is: storage/update/delete operations are always successful,
+    however retrieve operations do not return anything relevant.
+    Mostly, retrieved messages will be :obj:`NotImplemented`.
+    """
+
+    def _new_store(self, store_id: str) -> MessageStore:
         return NullMessageStore()
 
+    async def _delete_store(self, store: MessageStore):
+        pass
 
-class NullMessageStore(MessageStore):
-    """ For testing purpose """
 
-    async def store(self, msg):
+class NullMessageStore(MessageStore):  # pragma: no cover
+    # made it a singleton for now, we could instead choose to have
+    # a 'logger: logger | None' constructor parameter
+    _instance: NullMessageStore | None = None
+
+    def __new__(cls):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    async def _store(self, msg: Message, ini_meta: dict[str, Any]) -> str:
+        """broken invariant: does not return :class:`str` because
+        (at least at time of writing) a None check is used in
+        :meth:`BaseChannel.handle` and it fails at least 1 test..."""
         return None
 
-    async def get(self, id):
-        return None
+    async def _delete(self, id: str):
+        pass
 
-    async def add_message_meta_infos(self, id, meta_info_name, info):
-        return None
-
-    async def get_message_meta_infos(self, id, meta_info_name=None):
-        return None if meta_info_name else {}
-
-    async def add_sub_message_state(self, id, sub_id, state):
-        return None
-
-    async def set_state_to_worst_sub_state(self, id):
-        return None
-
-    async def get_preview_str(self, id):
-        return None
-
-    async def change_message_state(self, id, new_state):
-        return None
-
-    async def generate_store_id_from_msg(self, msg):
-        return None
-
-    async def get_msg_content(self, id):
-        return None
-
-    async def search(self, **kwargs):
-        return None
-
-    async def total(self):
+    async def _total(self) -> int:
         return 0
 
-    async def delete(self, id):
-        return None
+    async def _get_message(self, id: str) -> Message:
+        """broken invariant: does not return :class:`Message`"""
+        return NotImplemented
 
+    async def _get_storemeta(self, id: str) -> dict[str, Any]:
+        return {}
 
-class FakeMessageStoreFactory(MessageStoreFactory):
-    """ Return an Fake message store """
-    def get_store(self, store_id):
-        return FakeMessageStore()
+    async def _set_storemeta(self, id: str, meta: dict[str, Any]):
+        pass
 
-
-class FakeMessageStore(MessageStore):
-    """ For testing purpose """
-
-    async def store(self, msg):
-        logger.debug("Should store message %s", msg)
-        return 'fake_id'
-
-    async def add_message_meta_infos(self, id, meta_info_name, info):
-        return None
-
-    async def get_message_meta_infos(self, id, meta_info_name=None):
-        return "processed" if meta_info_name else {}
-
-    async def get(self, id):
-        return {'id': id, 'state': 'processed', 'message': None}
-
-    async def get_preview_str(self, id):
-        return {"id": id, "message_content": "content"}
-
-    async def get_msg_content(self, id):
-        return {"id": id, "message_content": "content"}
-
-    async def is_regex_in_msg(self, id, rtext):
-        return True
-
-    async def is_txt_in_msg(self, id, text):
-        return True
-
-    async def change_message_state(self, id, new_state):
-        return None
-
-    async def add_sub_message_state(self, id, sub_id, state):
-        return None
-
-    async def set_state_to_worst_sub_state(self, id):
-        return None
-
-    async def search(self, **kwargs):
+    async def _span_select(self, start_dt: datetime | None, end_dt: datetime | None) -> list[str]:
         return []
-
-    async def total(self):
-        return 0
-
-    async def delete(self, id):
-        """
-            we delete nothing here, but return what would have been deleted
-            (for testing)
-        """
-        return {'id': id, 'state': 'processed', 'message': None}
 
 
 class MemoryMessageStoreFactory(MessageStoreFactory):
-    """ Return a Memory message store. All message are lost at pypeman stop. """
-    def __init__(self):
-        self.base_dict = {}
+    """An in-memory message store.
 
-    def get_store(self, store_id):
-        return MemoryMessageStore(self.base_dict, store_id)
+    All messages are lost at pypeman stop.
+    """
+
+    def _new_store(self, store_id: str) -> MessageStore:
+        return MemoryMessageStore()
+
+    async def _delete_store(self, store: MessageStore):
+        assert isinstance(store, MemoryMessageStore)  # type narrowing
+        # private usage in friend class
+        store._sorted.clear()
+        store._mapped.clear()
 
 
 class MemoryMessageStore(MessageStore):
-    """ Store messages in memory """
+    class MemoryStoredEntry_(TypedDict):
+        meta: dict[str, Any]
+        message: dict[str, Any]  # for now messages are still `to_dict`-ified, this may change
+        timestamp: datetime
 
-    def __init__(self, base_dict, store_id):
+    def __init__(self):
         super().__init__()
-        self.messages = base_dict.setdefault(store_id, OrderedDict())
+        # this is a list so that it can be sort-inserted by timestamp
+        self._sorted: list[MemoryMessageStore.MemoryStoredEntry_] = []
+        # accompanying mapping for direct accesses by id
+        self._mapped: dict[str, MemoryMessageStore.MemoryStoredEntry_] = {}
+        # 2 references are stored to the same entry for 2 different usage
 
-    async def store(self, msg):
-        msg_id = msg.uuid
-        self.messages[msg_id] = {
-            'id': msg_id, 'state': Message.PENDING,
-            'timestamp': msg.timestamp, 'message': msg.to_dict()}
-        return msg_id
+    async def _store(self, msg: Message, ini_meta: dict[str, Any]) -> str:
+        if msg.uuid in self._mapped:
+            raise ValueError(f"message {msg} is being stored again in {self}")
 
-    async def change_message_state(self, id, new_state):
-        await self.add_message_meta_infos(id, "state", new_state)
+        entry: MemoryMessageStore.MemoryStoredEntry_ = {
+            "meta": ini_meta,
+            "message": msg.to_dict(),
+            "timestamp": msg.timestamp,
+        }
 
-    async def add_message_meta_infos(self, id, meta_info_name, info):
-        self.messages[id][meta_info_name] = info
-
-    async def get_message_meta_infos(self, id, meta_info_name=None):
-        return self.messages[id][meta_info_name] if meta_info_name else self.messages[id]
-
-    async def get(self, id):
-        resp = dict(self.messages[id])
-        resp['message'] = Message.from_dict(resp['message'])
-        return resp
-
-    async def get_preview_str(self, id):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)[:1000]
-        except Exception:
-            msg.payload = repr(msg.payload)[:1000]
-        return msg
-
-    async def get_msg_content(self, id):
-        msg = await self.get(id)
-        msg_content = msg["message"]
-        return msg_content
-
-    async def is_regex_in_msg(self, id, rtext):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)
-        except Exception:
-            msg.payload = repr(msg.payload)
-        regex = re.compile(rtext)
-        return True if regex.match(msg.payload) else False
-
-    async def is_txt_in_msg(self, id, text):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)
-        except Exception:
-            msg.payload = repr(msg.payload)
-        return text in msg.payload
-
-    async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None, meta=None):
-        if start and start_id:
-            raise ValueError("`start` and `start_id` can't both be set")
-        if order_by.startswith('-'):
-            reverse = True
-            sort_key = order_by[1:]
+        # sort-insert with assumption that the new message is more likely to go at the end
+        for k in range(len(self._sorted), 0, -1):
+            if self._sorted[k - 1]["timestamp"] <= msg.timestamp:
+                self._sorted.insert(k, entry)
+                break
         else:
-            reverse = False
-            sort_key = order_by
+            self._sorted.insert(0, entry)
 
-        if start_dt:
-            start_dt = dateutil.parser.isoparse(start_dt)
-        if end_dt:
-            end_dt = dateutil.parser.isoparse(end_dt)
+        self._mapped[msg.uuid] = entry
+        return msg.uuid
 
-        result = []
-        values = (
-            val for val in self.messages.values()
-            if (not start_dt or val["timestamp"] >= start_dt)
-            and (not end_dt or val["timestamp"] <= end_dt)
-        )
-        if text:
-            found_values = []
-            for val in values:
-                if await self.is_txt_in_msg(val["id"], text):
-                    found_values.append(val)
-            values = found_values
+    async def _delete(self, id: str):
+        msg = self._mapped.pop(id)
+        self._sorted.remove(msg)
 
-        if rtext:
-            found_values = []
-            for val in values:
-                if await self.is_regex_in_msg(val["id"], rtext):
-                    found_values.append(val)
-            values = found_values
+    async def _total(self) -> int:
+        return len(self._sorted)
 
-        ordered_list = sorted(values, key=lambda x: x[sort_key], reverse=reverse)
-        if start:
-            filtered_iterator = islice(
-                ordered_list,
-                start, start + count
-            )
-        elif start_id:
-            for idx, msgdict in enumerate(ordered_list):
-                if msgdict["id"] == start_id:
-                    start_id_idx = idx + 1
-                    break
+    async def _get_message(self, id: str) -> Message:
+        return Message.from_dict(self._mapped[id]["message"])
+
+    async def _get_storemeta(self, id: str) -> dict[str, Any]:
+        return deepcopy(self._mapped[id]["meta"])
+
+    async def _set_storemeta(self, id: str, meta: dict[str, Any]):
+        self._mapped[id]["meta"] = meta
+
+    async def _span_select(self, start_dt: datetime | None, end_dt: datetime | None) -> list[str]:
+        # test degenerate cases first
+        if start_dt and self._sorted[-1]["timestamp"] < start_dt:
+            return []
+        if end_dt and end_dt <= self._sorted[0]["timestamp"]:
+            return []
+
+        start, end = 0, len(self._sorted)
+
+        if start_dt is not None:
+            for start, entry in enumerate(self._sorted):
+                if start_dt <= entry["timestamp"]:
+                    break  # start found
+            # no `else`: degenerate cases test ensure it's found
+
+        if end_dt is not None:
+            for end in range(start + 1, len(self._sorted)):
+                if end_dt <= self._sorted[end]["timestamp"]:
+                    break  # end found
             else:
-                raise IndexError("Couldn't find start_id %r in filtered results", start_id)
-            filtered_iterator = islice(
-                ordered_list,
-                start_id_idx, start_id_idx + count
-            )
-        else:
-            filtered_iterator = islice(
-                ordered_list,
-                0, count
-            )
-        for value in filtered_iterator:
-            resp = dict(value)
-            resp['message'] = Message.from_dict(resp['message'])
-            result.append(resp)
-        return result if meta is None else MessageStore._search_meta_filter_sort(meta, result)
+                end = len(self._sorted)
 
-    async def total(self):
-        return len(self.messages)
-
-    async def delete(self, id):
-        resp = dict(self.messages.pop(id))
-        resp['message'] = Message.from_dict(resp['message'])
-        return resp
+        return [msg["message"]["uuid"] for msg in self._sorted[start:end]]
 
 
 class FileMessageStoreFactory(MessageStoreFactory):
-    """
-    Generate a FileMessageStore message store instance.
-    Store a file in `<base_path>/<store_id>/<year>/<month>/<day>/` hierachy.
+    """A filesystem-based message store.
+
+    Messages are stored in file pairs under
+    `<base_path>/<store_id>/<year>/<month>/<day>/`:
+        * `<timestamp>_<uuid>.meta`  the store-related meta;
+        * `<timestamp>_<uuid>`       the actual message.
+
+    The `<timestamp>` part is as :obj:`FileMessageStore.DATE_FORMAT`.
     """
 
-    # TODO add an option to reguraly archive old file or delete them
-    def __init__(self, path):
+    # TODO: see if both the parameter and the property names can be harmonized/privatized
+    def __init__(self, path: str | PurePath):
         super().__init__()
-        if path is None:
-            raise PypemanConfigError('file message store requires a path')
-        self.base_path = path
+        # sanity check
+        if not isinstance(path, (str, PurePath)):
+            raise PypemanConfigError("file message store requires a path")  # pragma: no cover
+        self.base_path = PurePath(path)
 
-    def get_store(self, store_id):
+    def _new_store(self, store_id: str) -> MessageStore:
+        # there **must not** be any of these char in `store_id`
+        # (matches the set of illegal DOS/Windows path characters)
+        assert not set(r'<>:"/\|?*') & set(store_id), f"store id {store_id!r} contains annoying characters"
         return FileMessageStore(self.base_path, store_id)
+
+    async def _delete_store(self, store: MessageStore):
+        assert isinstance(store, FileMessageStore)  # type narrowing
+        # private usage in friend class
+        store._latest = datetime.min
+        store._earliest = datetime.max
+
+        def rmrf(path: Path):
+            "helper for older pathlib without :meth:`Path.walk`"
+            for child in path.iterdir():
+                if not child.is_symlink() and child.is_dir():
+                    rmrf(child)
+                else:
+                    child.unlink()
+            path.rmdir()
+
+        rmrf(store.base_path)
 
 
 class FileMessageStore(MessageStore):
-    """ Store a file in `<base_path>/<store_id>/<year>/<month>/<day>/` hierachy."""
-    # TODO file access should be done in another thread. Waiting for file backend.
+    """
 
-    def __init__(self, path, store_id):
+    Ids are of the form `'{date}_{time}_{uuid}'`. Again, message store
+    ids are **implementation details** and **must not be inspected**
+    other than for debugging/logging/.. purposes!
+    """
+
+    DATE_FORMAT = "%Y%m%d_%H%M%S%f"  # 21 guaranteed length (8+1+12)
+    _PARSE_ID = re.compile(
+        """
+        ^
+            (?P<year>[0-9]{4})
+            (?P<month>[0-9]{2})
+            (?P<day>[0-9]{2})
+        _
+            (?P<hour>[0-9]{2})
+            (?P<minute>[0-9]{2})
+            ( # an older format didn't have sec/usec
+                (?P<second>[0-9]{2})
+                (?P<microsecond>[0-9]{6})
+            )?
+        _
+            (?P<uid>[0-9a-zA-Z]*)
+        $
+        """,
+        re.VERBOSE,
+    )
+
+    # TODO: reporting an older todo about making more things async:
+    #   see https://github.com/python/asyncio/wiki/ThirdParty#filesystem
+    #   as well as the refered https://github.com/Tinche/aiofiles/
+    #   as of now, even tho everything is marked async, none is-
+    #   (lastely this likely doesnt matter, I'll try to benchmark both
+    #   somewhat to prove otherwise.. I do belive it would speed up
+    #   `get_many` quite a bit but not so sure)
+
+    def __init__(self, path: PurePath, store_id: str):
         super().__init__()
+        # TODO: see if property name and parameter names can be changed/harmonized/privatized
+        self.base_path = Path(path, store_id)
+        # reminder: don't touch file system here! wait for `start`
 
-        self.base_path = os.path.join(path, store_id)
+    async def _start(self):
+        self.base_path.mkdir(parents=True, exist_ok=True)
 
-        # Match msg file name
-        self.old_msg_re = re.compile(
-            r'^(?P<msg_date>[0-9]{8})_(?P<msg_time>[0-9]{2}[0-9]{2})_(?P<msg_uid>[0-9a-zA-Z]*)$')
-        self.msg_re = re.compile(
-            r'^(?P<msg_date>[0-9]{8})_(?P<msg_time>[0-9]{2}[0-9]{2}[0-9]{2}[0-9]{6})_(?P<msg_uid>[0-9a-zA-Z]*)$'  # noqa: E501
+        every = sorted(
+            file.name
+            for file in self.base_path.glob("*/*/*/*")  # <y>/<m>/<d>/<file>
+            if file.is_file() and FileMessageStore._PARSE_ID.match(file.name) is not None
         )
+        if not every:
+            self._earliest = datetime.max
+            self._latest = datetime.min
 
-        try:
-            # Try to make dirs if necessary
-            os.makedirs(os.path.join(self.base_path))
-        except FileExistsError:
-            pass
+        else:
+            res = FileMessageStore._PARSE_ID.match(every[0])
+            ymd_hmsf = res.group("year", "month", "day", "hour", "minute", "second", "microsecond")
+            self._earliest = datetime(*(int(t or 0) for t in ymd_hmsf))
 
-        self._total = 0
+            res = FileMessageStore._PARSE_ID.match(every[-1])
+            ymd_hmsf = res.group("year", "month", "day", "hour", "minute", "second", "microsecond")
+            self._latest = datetime(*(int(t or 0) for t in ymd_hmsf))
 
-    def id2path(self, id):
-        old_match = self.old_msg_re.match(id)
-        match = self.msg_re.match(id)
-        if not (match or old_match):
-            raise ValueError(f"Id '{id}' not a correct id")
-        if old_match:
-            match = old_match
-        msg_str_date = match.groupdict()["msg_date"]
-        year = msg_str_date[:4]
-        month = msg_str_date[4:6]
-        day = msg_str_date[6:8]
-        msg_path = Path(self.base_path) / year / month / day / id
-        return msg_path
+    def _dt2dir(self, dt: datetime | date) -> Path:
+        """Build the dir path where messages for day `dt` are/would be.
 
-    async def start(self):
-        self._total = await self.count_msgs()
+        For use with an already assembled id prefer :meth:`_id2file`.
+        This method is implementation detail.
 
-    async def store(self, msg):
-        """ Store a file in `<base_path>/<store_id>/<month>/<day>/` hierachy."""
-        # TODO implement a safer store to avoid broken messages
+        :param dt: Date.
+        :return: Directory path.
+        """
+        return self.base_path / f"{dt.year:04}" / f"{dt.month:02}" / f"{dt.day:02}"
 
-        # The filename is the file id
-        filename = "{}_{}".format(msg.timestamp.strftime(DATE_FORMAT), msg.uuid)
-        msg_path = self.id2path(filename)
+    def _id2file(self, id: str) -> Path:
+        """For a vaild `id`, build the corresponding file path.
+
+        For use with a plain dt/timestamp prefer :meth:`_dt2dir`.
+        This method is implementation detail.
+
+        :param id: `'{date}_{time}_{uuid}'`.
+        :return: Suffix-less file path.
+        :raise LookupError: Cannot parse `id`.
+        """
+        res = FileMessageStore._PARSE_ID.match(id)
+        if not res:
+            raise LookupError(f"unknown id format {id!r}")
+        gd = res.groupdict()
+        return self.base_path / gd["year"] / gd["month"] / gd["day"] / id
+
+    async def _store(self, msg: Message, ini_meta: dict[str, Any]) -> str:
+        id = f"{msg.timestamp.strftime(FileMessageStore.DATE_FORMAT)}_{msg.uuid}"
+        # at time of writing :class:`Message` isn't correctly typed (*at all)
+        # these two lines are to enforce correct type (the aliase can be removed when updated)
+        timestamp: ... = msg.timestamp
+        timestamp: datetime
+        msg_path = self._dt2dir(timestamp) / id
+
+        if msg_path.exists():
+            raise ValueError(f"message {msg} is being stored again in {self}")
+
         msg_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write message to file
         with msg_path.open("w") as f:
             f.write(msg.to_json())
+        with msg_path.with_suffix(".meta").open("w") as f:
+            json.dump(ini_meta, f)
 
-        await self.change_message_state(filename, Message.PENDING)
+        if timestamp < self._earliest:
+            self._earliest = timestamp
+        if self._latest < timestamp:
+            self._latest = timestamp
 
-        self._total += 1
+        return id
 
-        return filename
+    async def _delete(self, id: str):
+        msg_path = self._id2file(id)
+        msg_path.unlink(missing_ok=True)
+        msg_path.with_suffix(".meta").unlink(missing_ok=True)
 
-    def _is_json_meta(self, id):
-        """Check if the message meta file is a json. If it's not,
-        the message is an old message that doesnt contain other infos in
-        meta except the state
+    async def _total(self) -> int:
+        return sum(
+            file.is_file() and FileMessageStore._PARSE_ID.match(file.name) is not None
+            for file in self.base_path.glob("*/*/*/*")  # <y>/<m>/<d>/<file>
+        )
 
-        Args:
-            id (str): The id of the message
-        """
-        msg_fpath = self.id2path(id)
-        meta_fpath = msg_fpath.with_suffix(".meta")
-        if not meta_fpath.exists():
-            return False
-        with meta_fpath.open("r") as fin:
-            try:
-                json.load(fin)
-                return True
-            except json.JSONDecodeError:
-                return False
+    async def _get_message(self, id: str) -> Message:
+        msg_path = self._id2file(id)
+        if not msg_path.exists():
+            raise LookupError(f"no message stored under {id!r}")
+        with msg_path.open("r") as f:
+            return Message.from_json(f.read())
 
-    def _convert_meta_to_json(self, id):
-        """Convert an old message meta to a new one (json)
+    async def _get_storemeta(self, id: str) -> dict[str, Any]:
+        meta_path = self._id2file(id).with_suffix(".meta")
+        if not meta_path.exists():
+            raise LookupError(f"no meta stored under {id!r}")
+        with meta_path.open("r") as f:
+            content = f.read().strip()
+        # (uuuuuuugh) still handle oldass format
+        return json.loads(content) if "{" == content[:1] else {"state": content}
 
-        Args:
-            id (str): The id of the message to convert
-        """
-        msg_fpath = self.id2path(id)
-        meta_fpath = msg_fpath.with_suffix(".meta")
-        with meta_fpath.open("r") as fin:
-            state = fin.read()
-        meta_data = {"state": state}
-        with meta_fpath.open("w") as fout:
-            json.dump(meta_data, fout)
-        return meta_data
+    async def _set_storemeta(self, id: str, meta: dict[str, Any]):
+        with self._id2file(id).with_suffix(".meta").open("w") as f:
+            json.dump(meta, f)
 
-    async def get_message_meta_infos(self, id, meta_info_name=None):
-        msg_fpath = self.id2path(id)
-        meta_fpath = msg_fpath.with_suffix(".meta")
-        if meta_fpath.exists():
-            is_new_meta_file = self._is_json_meta(id)
-            if not is_new_meta_file:
-                meta_data = self._convert_meta_to_json(id)
-            else:
-                with meta_fpath.open("r") as fin:
-                    meta_data = json.load(fin)
-        else:
-            meta_data = {}
+    async def _span_select(self, start_dt: datetime | None, end_dt: datetime | None) -> list[str]:
+        # test degenerate cases first
+        if start_dt and self._latest < start_dt:
+            return []
+        if end_dt and end_dt <= self._earliest:
+            return []
 
-        if meta_info_name:
-            meta_data = meta_data.get(meta_info_name)
-        return meta_data
+        start_dt = start_dt or self._earliest
+        end_dt = end_dt or self._latest + timedelta(hours=1)  # as to include the last day
 
-    async def add_message_meta_infos(self, id, meta_info_name, info):
-        msg_fpath = self.id2path(id)
-        meta_fpath = msg_fpath.with_suffix(".meta")
-        if meta_fpath.exists():
-            is_new_meta_file = self._is_json_meta(id)
-            if not is_new_meta_file:
-                meta_data = self._convert_meta_to_json(id)
-            else:
-                with meta_fpath.open("r") as fin:
-                    meta_data = json.load(fin)
-        else:
-            meta_data = {}
+        start_date = start_dt.date()
+        end_date = end_dt.date()
+        one_day = timedelta(days=1)
 
-        meta_data[meta_info_name] = info
-        with meta_fpath.open("w") as fout:
-            json.dump(meta_data, fout)
+        ids: list[str] = []
+        current_date = start_date
+        while current_date <= end_date:
+            dir = self._dt2dir(current_date)
+            if dir.is_dir():
+                for file in sorted(dir.iterdir(), key=lambda file: file.name):
+                    # check it's a well-formed id
+                    res = FileMessageStore._PARSE_ID.match(file.name)
+                    if not res:
+                        continue
+                    # check its dt is within span
+                    ymd_hmsf = res.group("year", "month", "day", "hour", "minute", "second", "microsecond")
+                    if start_dt <= datetime(*(int(t or 0) for t in ymd_hmsf)) < end_dt:
+                        ids.append(file.name)
+            current_date += one_day
 
-    async def change_message_state(self, id, new_state):
-        await self.add_message_meta_infos(id, "state", new_state)
+        return ids
 
-    async def get_message_state(self, id):
-        return await self.get_message_meta_infos(id, "state")
 
-    async def get(self, id):
-        fpath = self.id2path(id)
-        if not fpath.exists():
-            raise IndexError
-
-        with fpath.open("rb") as f:
-            msg = Message.from_json(f.read().decode('utf-8'))
-            return {
-                'id': id,
-                'state': await self.get_message_state(id),
-                'message': msg,
-                "meta": await self.get_message_meta_infos(id)
-            }
-
-    async def get_preview_str(self, id):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)[:1000]
-        except Exception:
-            msg.payload = repr(msg.payload)[:1000]
-        return msg
-
-    async def get_msg_content(self, id):
-        msg = await self.get(id)
-        msg_content = msg["message"]
-        return msg_content
-
-    async def sorted_list_directories(self, path, reverse=True):
-        """
-        :param path: Base path
-        :param reverse: reverse order
-        :return: List of directories in specified path ordered
-        """
-        return sorted([d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))], reverse=reverse)
-
-    async def count_msgs(self):
-        """
-        Count message by listing all directories. To be used at startup.
-        """
-        count = 0
-        for year in await self.sorted_list_directories(os.path.join(self.base_path)):
-            for month in await self.sorted_list_directories(os.path.join(self.base_path, year)):
-                for day in await self.sorted_list_directories(os.path.join(self.base_path, year, month)):
-                    for msg_id in sorted(os.listdir(os.path.join(self.base_path, year, month, day))):
-                        old_found = self.old_msg_re.match(msg_id)
-                        found = self.msg_re.match(msg_id)
-                        if found or old_found:
-                            count += 1
-        return count
-
-    async def is_regex_in_msg(self, id, rtext):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)
-        except Exception:
-            msg.payload = repr(msg.payload)
-        regex = re.compile(rtext)
-        return True if regex.match(msg.payload) else False
-
-    async def is_txt_in_msg(self, id, text):
-        msg = await self.get_msg_content(id)
-        try:
-            msg.payload = str(msg.payload)
-        except Exception:
-            msg.payload = repr(msg.payload)
-        return text in msg.payload
-
-    async def search(self, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
-                     text=None, rtext=None, start_id=None, meta=None):
-        if start and start_id:
-            raise ValueError("`start` and `start_id` can't both be set")
-        # TODO better performance for slicing by counting file in dirs ?
-        if order_by.startswith('-'):
-            reverse = True
-            # sort_key = order_by[1:]
-        else:
-            reverse = False
-            # sort_key = order_by
-
-        if start_dt:
-            start_dt = dateutil.parser.isoparse(start_dt)
-        if end_dt:
-            end_dt = dateutil.parser.isoparse(end_dt)
-
-        # TODO handle sort_key
-        result = []
-        end = start + count
-        position = 0
-        start_id_found = False
-        for year in await self.sorted_list_directories(
-                os.path.join(self.base_path), reverse=reverse):
-            for month in await self.sorted_list_directories(
-                    os.path.join(self.base_path, year), reverse=reverse):
-                for day in await self.sorted_list_directories(
-                        os.path.join(self.base_path, year, month), reverse=reverse):
-                    # Pre filter with date to avoid listing unuseful dirs
-                    msg_date = datetime.date(year=int(year), month=int(month), day=int(day))
-                    if start_dt:
-                        if msg_date < start_dt.date():
-                            continue
-                    if end_dt:
-                        if msg_date > end_dt.date():
-                            continue
-                    for msg_id in sorted(
-                            os.listdir(os.path.join(
-                                self.base_path, year, month, day)),
-                            reverse=reverse):
-                        if not start_id_found and start_id and msg_id != start_id:
-                            continue
-                        elif not start_id_found and start_id and msg_id == start_id:
-                            start_id_found = True
-                            continue
-                        old_found = self.old_msg_re.match(msg_id)
-                        found = self.msg_re.match(msg_id)
-                        if found or old_found:
-                            if old_found:
-                                msg_str_time = found.groupdict()["msg_time"]
-                                hour = int(msg_str_time[:2])
-                                minute = int(msg_str_time[2:4])
-                                second = 0
-                                microsecond = 0
-                            if found:
-                                msg_str_time = found.groupdict()["msg_time"]
-                                hour = int(msg_str_time[:2])
-                                minute = int(msg_str_time[2:4])
-                                second = int(msg_str_time[4:6])
-                                microsecond = int(msg_str_time[6:12])
-                            msg_time = datetime.time(
-                                hour=hour,
-                                minute=minute,
-                                second=second,
-                                microsecond=microsecond,
-                            )
-                            msg_dt = datetime.datetime.combine(msg_date, msg_time)
-                            if start_dt:
-                                if msg_dt < start_dt:
-                                    continue
-                            if end_dt:
-                                if msg_dt > end_dt:
-                                    continue
-                            if text:
-                                if not await self.is_txt_in_msg(msg_id, text):
-                                    continue
-                            if rtext:
-                                if not await self.is_regex_in_msg(msg_id, rtext):
-                                    continue
-                            if start <= position < end:
-                                # TODO: need to do processing of payload
-                                #       before filtering (HL7 / json-str)
-                                # TODO: add filter here
-                                # TODO: can we transfoer into a generator?
-                                result.append(await self.get(msg_id))
-                            elif position >= end:
-                                break
-                            position += 1
-        if start_id and not start_id_found:
-            raise IndexError("Couldn't find start_id %r in filtered results", start_id)
-        return result if meta is None else MessageStore._search_meta_filter_sort(meta, result)
-
-    async def total(self):
-        return self._total
-
-    async def _delete_meta_file(self, id):
-        msg_path = self.id2path(id)
-        meta_fpath = msg_path.with_suffix(".meta")
-        meta_fpath.unlink()
-
-    async def delete(self, id):
-        fpath = self.id2path(id)
-        if not fpath.exists():
-            raise IndexError
-
-        with fpath.open("rb") as f:
-            msg = Message.from_json(f.read().decode('utf-8'))
-
-        data_to_return = {'id': id, 'state': await self.get_message_state(id), 'message': msg}
-        fpath.unlink()
-        await self._delete_meta_file(id=id)
-        return data_to_return
+# TODO: this is specific to the FileMessageStore, remove the top-level alias
+DATE_FORMAT = FileMessageStore.DATE_FORMAT

--- a/pypeman/plugins/remoteadmin/views.py
+++ b/pypeman/plugins/remoteadmin/views.py
@@ -77,7 +77,6 @@ async def list_msgs(request, ws=None):
     :params channelname: The channel name.
 
     :queryparams:
-        start (int, default=0): OBSOLETE (use start_id instead) the start indexof msgs to list
         start_id (str, default=None): the start id from which search starts (start_d excluded from results)
         count (count, default=10): The maximum returned msgs
         order_by (str, default="timestamp"): the message attribute to use for sorting
@@ -93,7 +92,6 @@ async def list_msgs(request, ws=None):
     chan = get_channel(channelname)
 
     args = request.rel_url.query
-    start = int(args.get("start", 0))
     start_id = args.get("start_id", None)
     count = int(args.get("count", 10))
     order_by = args.get("order_by", "-timestamp")
@@ -109,7 +107,7 @@ async def list_msgs(request, ws=None):
 
     try:
         messages = await chan.message_store.search(
-            start=start, count=count, order_by=order_by, start_dt=start_dt, end_dt=end_dt,
+            count=count, order_by=order_by, start_dt=start_dt, end_dt=end_dt,
             text=text, rtext=rtext, start_id=start_id, meta=meta) or []
     except Exception:
         logger.exception("Cannot search messages")
@@ -282,14 +280,13 @@ async def backport_old_client(request):
             await replay_msg(request=request, ws=ws)
         elif cmd_method == "list_msgs":
             query_params = {
-                "start": params[1],
-                "count": params[2],
-                "order_by": params[3],
-                "start_dt": params[4],
-                "end_dt": params[5],
-                "text": params[6],
-                "rtext": params[7],
-                "start_id": params[8],
+                "count": params[1],
+                "order_by": params[2],
+                "start_dt": params[3],
+                "end_dt": params[4],
+                "text": params[5],
+                "rtext": params[6],
+                "start_id": params[7],
             }
             query_params = {k: v for k, v in query_params.items() if v is not None}
             query_url = request.rel_url.with_query(query_params)

--- a/pypeman/plugins/tests/test_remoteadmin.py
+++ b/pypeman/plugins/tests/test_remoteadmin.py
@@ -127,7 +127,7 @@ class TestRemoteAdminPlugin(RemoteAdminBaseMixin):
 
     async def test_search_messages(self, webremoteclient):
         params = {
-            "start": 2,
+            "start_id": self.msg4.uuid,
             "count": 5,
             "order_by": "-timestamp"
         }

--- a/pypeman/remoteadmin.py
+++ b/pypeman/remoteadmin.py
@@ -6,7 +6,6 @@ import logging
 import re
 import sys
 
-from datetime import datetime
 # TODO use readline for history ?
 # import readline
 
@@ -140,7 +139,7 @@ class RemoteAdminServer():
         }
 
     @method
-    async def list_msgs(self, channel, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
+    async def list_msgs(self, channel, count=10, order_by='timestamp', start_dt=None, end_dt=None,
                         text=None, rtext=None, start_id=None):
         """
         List first `count` messages from message store of specified channel.
@@ -150,16 +149,13 @@ class RemoteAdminServer():
         chan = self.get_channel(channel)
 
         messages = await chan.message_store.search(
-            start=start, count=count, order_by=order_by, start_dt=start_dt, end_dt=end_dt,
+            count=count, order_by=order_by, start_dt=start_dt, end_dt=end_dt,
             text=text, rtext=rtext, start_id=start_id) or []
 
         for res in messages:
-            timestamp = res['timestamp']
-            if isinstance(timestamp, datetime):
-                timestamp = datetime.timestamp(timestamp)
-            res['timestamp'] = timestamp
             res['id'] = res['id']
             res['state'] = res["state"]
+            res['timestamp'] = res['message'].timestamp_str()
             if "message" in res:
                 res.pop("message")
 
@@ -291,13 +287,12 @@ class RemoteAdminClient():
         """
         return self.send_command('stop_channel', [channel])
 
-    def list_msgs(self, channel, start=0, count=10, order_by='timestamp', start_dt=None, end_dt=None,
+    def list_msgs(self, channel, count=10, order_by='timestamp', start_dt=None, end_dt=None,
                   text=None, rtext=None, start_id=None):
         """
         List first 10 messages on specified channel from remote instance.
 
         :params channel: The channel name.
-        :params start: Start index of listing.
         :params count: Count from index.
         :params start_dt: (optional) start datetime filter (isoformat)
         :params end_dt: (optional) start datetime filter (isoformat)
@@ -306,7 +301,7 @@ class RemoteAdminClient():
         :params order_by: Message order. only 'timestamp' and '-timestamp' handled for now.
         :returns: list of message with status.
         """
-        list_msg_args = [channel, start, count, order_by, start_dt, end_dt, text, rtext, start_id]
+        list_msg_args = [channel, count, order_by, start_dt, end_dt, text, rtext, start_id]
         result = self.send_command('list_msgs', list_msg_args)
 
         for m in result['messages']:
@@ -450,7 +445,7 @@ class PypemanShell(cmd.Cmd):
     @_with_current_channel
     def do_list(self, channel, arg):
         """
-        List messages of selected channel. You can specify start, end and order_by arguments
+        List messages of selected channel. You can specify count and order_by arguments
         Optional args:
             - to filter messages, you can pass start_dt and end_dt (isoformat datetimes)
             to filter messages
@@ -465,7 +460,7 @@ class PypemanShell(cmd.Cmd):
         args = arg.split()
         if dquote_args:
             args.extend(dquote_args)
-        start, end, order_by = 0, 100, '-timestamp'
+        count, order_by = 100, '-timestamp'
         start_dt = None
         end_dt = None
         text = None
@@ -493,14 +488,12 @@ class PypemanShell(cmd.Cmd):
                     args.remove(arg)
 
         # Parsing of common args
-        if args:
-            start = int(args[0])
+        if len(args) > 0:
+            count = int(args[0])
         if len(args) > 1:
-            end = int(args[1])
-        if len(args) > 2:
-            order_by = args[2]
+            order_by = args[1]
         result = self.client.list_msgs(
-            channel, start, end, order_by, start_dt=start_dt, end_dt=end_dt,
+            channel, count, order_by, start_dt=start_dt, end_dt=end_dt,
             text=text, rtext=rtext, start_id=start_id)
 
         if not result['total']:

--- a/pypeman/retry.py
+++ b/pypeman/retry.py
@@ -45,7 +45,7 @@ class RetryFileMsgStore(FileMessageStore):
 
     async def start(self):
         await super().start()
-        cnt_msgs = await self.count_msgs()
+        cnt_msgs = await self.total()
         if cnt_msgs > 0:
             await self.start_retry_mode()
 
@@ -73,6 +73,14 @@ class RetryFileMsgStore(FileMessageStore):
         await self.add_message_meta_infos(id=id, meta_info_name="store_chan_name", info=store_chan_name)
         if self.state != self.RETRY_MODE:
             await self.start_retry_mode()
+
+    async def sorted_list_directories(self, path, reverse=True):
+        """
+        :param path: Base path
+        :param reverse: reverse order
+        :return: List of directories in specified path ordered
+        """
+        return sorted([d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))], reverse=reverse)
 
     async def search_by_store_id(self, store_id, count=0):
         """Returns a list of <count> messages ids for a given store_id
@@ -196,13 +204,13 @@ class RetryFileMsgStore(FileMessageStore):
                 await self.retry_one_store_id(msg_store_id=message_store_id)
                 logger.debug(
                     f"Retrystore Retry {self.channel.short_name}: Retry of "
-                    f"store_id={ message_store_id } Done"
+                    f"store_id={message_store_id} Done"
                 )
                 continue
             except exceptions.RetryException:
                 logger.debug(
                     f"Retrystore Retry {self.channel.short_name}: Retry of "
-                    f"store_id={ message_store_id } not good: RetryExc catched,"
+                    f"store_id={message_store_id} not good: RetryExc catched,"
                     " will retry later"
                 )
                 retry_exc_catched = True
@@ -210,7 +218,7 @@ class RetryFileMsgStore(FileMessageStore):
             except Exception:
                 logger.debug(
                     f"Retrystore Retry {self.channel.short_name}: Retry of "
-                    f"store_id={ message_store_id } Done (with err)"
+                    f"store_id={message_store_id} Done (with err)"
                 )
                 continue
             finally:

--- a/pypeman/tests/test_msgstore.py
+++ b/pypeman/tests/test_msgstore.py
@@ -1,472 +1,510 @@
+from __future__ import annotations
 
-import asyncio
-import json
-import os
-import shutil
-import tempfile
+from datetime import datetime
+from datetime import timedelta
+from re import error as ReError
+from typing import Any
+from typing import Literal
 
-from pathlib import Path
+import pytest
 
-from pypeman import channels
-from pypeman import message
-from pypeman import msgstore
-from pypeman import nodes
-from pypeman.channels import BaseChannel
-from pypeman.message import Message
-from pypeman.test import TearDownProjectTestCase as TestCase
-from pypeman.tests.common import generate_msg
-from pypeman.tests.common import TstException
-from pypeman.tests.common import TstNode
+from .. import msgstore
+from ..message import Message
+from ..msgstore import MessageStoreFactory
 
+TESTED_STORE_FACTORIES = [
+    # can't be tested generically, breaks too many invariants
+    # (msgstore.NullMessageStoreFactory, ()),
+    (msgstore.MemoryMessageStoreFactory, ()),
+    (msgstore.FileMessageStoreFactory, ("/tmp/test/this/out",)),
+]
 
-class ObjectWithoutStr:
-    def __str__(self):
-        raise NotImplementedError("__str__ not implemented")
-
-
-class TstConditionalErrorNode(nodes.BaseNode):
-
-    def process(self, msg):
-        print("Process %s" % self.name)
-
-        if isinstance(msg.payload, str) and "shall_fail" in msg.payload:
-            raise TstException()
-
-        return msg
+TESTED_PERSISTENT_STORE_FACTORIES = [
+    (msgstore.FileMessageStoreFactory, ("/tmp/test/this/out",)),
+]
 
 
-class MsgstoreTests(TestCase):
-    def clean_loop(self):
-        # Useful to execute future callbacks
-        pending = asyncio.all_tasks(loop=self.loop)
+@pytest.fixture(scope="function", params=TESTED_STORE_FACTORIES, ids=lambda p: p[0])
+async def factory(request):
+    "Fixture that, when used in a test function, will test every store."
+    current: ... = request.param
+    current: tuple[type[MessageStoreFactory], tuple[object, ...]]
 
-        if pending:
-            self.loop.run_until_complete(asyncio.gather(*pending))
+    cls, args = current
+    factory = cls(*args)
+    yield factory
 
-    def start_channels(self):
-        # Start channels
-        for chan in channels.all_channels:
-            self.loop.run_until_complete(chan.start())
+    for store_id in factory.list_store():
+        await factory.delete_store(store_id)
 
-    def setUp(self):
-        # Create class event loop used for tests to avoid failing
-        # previous tests to impact next test ? (Not sure)
-        self.loop = asyncio.new_event_loop()
-        self.loop.set_debug(True)
-        # Remove thread event loop to be sure we are not using
-        # another event loop somewhere
-        asyncio.set_event_loop(None)
 
-        # Avoid calling already tested channels
-        channels.all_channels.clear()
+async def test_store_identity(factory: MessageStoreFactory):
+    store_a = factory.get_store("a")
+    store_b = factory.get_store("b")
+    assert store_a is not store_b
+    store_a_again = factory.get_store("a")
+    assert store_a is store_a_again
 
-    def tearDown(self):
-        super().tearDown()
-        self.clean_loop()
 
-    def test_null_message_store(self):
-        """ We can store a message in NullMessageStore """
+async def test_store_retrieve(factory: MessageStoreFactory):
+    """For a restored message, it ensures the following:
+    * timestamp is a datetime and equal to original
+    * uuid is a str and equal to original
+    * payload
+    * meta is a POPO (ie. json-compatible) dict
+    * ctx is a plain dict of dicts with `'payload'` `'meta'`
+    """
+    store = factory.get_store("a")
+    await store.start()
 
-        chan = BaseChannel(
-            name="test_channel9", loop=self.loop,
-            message_store_factory=msgstore.FakeMessageStoreFactory())
-        n = TstNode()
-        msg = generate_msg(with_context=True)
+    msg = Message(
+        payload="thingymabob",
+        meta={
+            "": "empty named meta",
+            "meta that is a list": [1, 2, 3],
+            "true": False,
+            "queneni": None,
+        },
+    )
+    id = await store.store(msg)
+    assert type(id) is str
 
-        chan.add(n)
+    entry = await store.get(id)
+    assert entry["id"] == id
 
-        # Launch channel processing
-        self.start_channels()
-        self.loop.run_until_complete(chan.handle(msg))
+    remsg = entry["message"]
+    assert remsg.timestamp == msg.timestamp
+    assert remsg.uuid == msg.uuid
+    assert remsg.payload == msg.payload
+    assert remsg.meta == msg.meta
+    assert remsg.ctx == msg.ctx
 
-        self.assertTrue(n.processed, "Channel handle not working")
 
-    def test_memory_message_store(self):
-        """ We can store a message in FileMessageStore """
+async def test_store_delete(factory: MessageStoreFactory):
+    "Using an `id` after a call to :meth:`MessageStore.delete` fails."
+    store = factory.get_store("a")
+    await store.start()
 
-        store_factory = msgstore.MemoryMessageStoreFactory()
+    id = await store.store(Message())
+    _ = await store.get(id)  # store successful, message exists
+    await store.delete(id)
 
-        chan = BaseChannel(name="test_channel10", loop=self.loop, message_store_factory=store_factory)
+    # do it with both implementation methods directly because we want
+    # to make sure both work (one might always shadow the other if eg the
+    # meta is always used first in implementation of says `.get`)
+    rose = None
+    try:
+        _ = await store._get_storemeta(id)
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, LookupError), rose
+    try:
+        _ = await store._get_message(id)
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, LookupError), rose
 
-        n = TstNode()
-        n_error = TstConditionalErrorNode()
 
-        msg = generate_msg(with_context=True)
-        msg2 = generate_msg(timestamp=(1982, 11, 27, 12, 35), message_content="message content2")
-        msg3 = generate_msg(timestamp=(1982, 11, 28, 12, 35), message_content="message content3")
-        msg4 = generate_msg(timestamp=(1982, 11, 28, 14, 35), message_content="message_content4")
+async def test_get_invalid(factory: MessageStoreFactory):
+    "Using a wrong `id` fails."
+    store = factory.get_store("a")
+    await store.start()
 
-        # This message should be in error
-        msg5 = generate_msg(timestamp=(1982, 11, 12, 14, 35),
-                            message_content='{"test1": "shall_fail"}')
-        msg6 = generate_msg(timestamp=(1982, 11, 28, 14, 35), message_content=ObjectWithoutStr())
-        msg2_uuid = msg2.uuid
-        chan.add(n)
-        chan.add(n_error)
+    id = await store.store(Message())
 
-        # Launch channel processing
-        self.start_channels()
-        self.loop.run_until_complete(chan.handle(msg))
-        self.loop.run_until_complete(chan.handle(msg2))
-        self.loop.run_until_complete(chan.handle(msg3))
-        self.loop.run_until_complete(chan.handle(msg4))
+    rose = None
+    try:
+        _ = await store._get_storemeta("nop!" + id)
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, LookupError), rose
+    try:
+        _ = await store._get_message("nop!" + id)
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, LookupError), rose
 
-        with self.assertRaises(TstException):
-            # This message should be in error state
-            self.loop.run_until_complete(chan.handle(msg5))
-        self.loop.run_until_complete(chan.handle(msg6))
-        msg6 = generate_msg(timestamp=(1982, 11, 28, 14, 35), message_content=ObjectWithoutStr())
 
-        self.assertEqual(self.loop.run_until_complete(chan.message_store.total()),
-                         6, "Should be a total of 6 messages in store!")
+async def test_store_state_management(factory: MessageStoreFactory):
+    "Updates to the state"
+    store = factory.get_store("a")
+    await store.start()
 
-        msg_stored1 = list(self.loop.run_until_complete(chan.message_store.search(0, 2)))
-        self.assertEqual(len(msg_stored1), 2, "Should be 2 results from search!")
+    id = await store.store(Message())
+    assert await store.get_message_state(id) == Message.PENDING
 
-        msg_stored2 = list(self.loop.run_until_complete(chan.message_store.search(2, 5)))
-        self.assertEqual(len(msg_stored2), 4, "Should be 4 results from search!")
+    await store.change_message_state(id, Message.PROCESSING)
+    assert await store.get_message_state(id) == Message.PROCESSING
 
-        msg_stored = list(self.loop.run_until_complete(chan.message_store.search()))
+    await store.change_message_state(id, Message.PROCESSED)
+    assert await store.get_message_state(id) == Message.PROCESSED
 
-        # All message stored ?
-        self.assertEqual(len(msg_stored), 6, "Should be 6 messages in store!")
 
-        for msg in msg_stored:
-            print(msg)
+async def test_double_store_message(factory: MessageStoreFactory):
+    "By double store I mean twice the same, (same uuid)."
+    store = factory.get_store("a")
+    await store.start()
 
-        for msg in msg_stored1 + msg_stored2:
-            print(msg)
+    msg = Message()
+    _ = await store.store(msg)
 
-        ids1 = [msg['id'] for msg in msg_stored1 + msg_stored2]
-        ids2 = [msg['id'] for msg in msg_stored]
+    rose = None
+    try:
+        _ = await store.store(msg)
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, ValueError), rose
 
-        self.assertEqual(ids1, ids2, "Should be 6 messages in store!")
 
-        # Test processed message
-        dict_msg = self.loop.run_until_complete(chan.message_store.get('%s' % msg3.uuid))
-        self.assertEqual(dict_msg['state'], 'processed', "Message %s should be in processed state!" % msg3)
+@pytest.mark.parametrize("cls,params", TESTED_PERSISTENT_STORE_FACTORIES)
+async def test_store_persistence(cls: type[MessageStoreFactory], params: ...):
+    "Store, shutdown, reboot, expect messages to still be there."
+    factory = cls(*params)
+    store = factory.get_store("a")
+    await store.start()
 
-        # Test failed message
-        dict_msg = self.loop.run_until_complete(chan.message_store.get('%s' % msg5.uuid))
-        self.assertEqual(dict_msg['state'], 'error', "Message %s should be in error state!" % msg5)
+    ids = [await store.store(Message(payload=k)) for k in range(3)]
 
-        # Test list messages
-        msgs = self.loop.run_until_complete(chan.message_store.search(start_id=msg2_uuid, count=5))
-        self.assertEqual(len(msgs), 4, "Failure of listing messages from memory msg store")
+    # pypeman shutdown (only thing that matter is to re-new 'factory' with same params)
+    del store, factory
 
-        # Test list messages with date filters
-        msgs = self.loop.run_until_complete(chan.message_store.search(
-            start_dt="1982-11-27", end_dt="1982-11-28T13:00:00"))
-        self.assertEqual(len(msgs), 2, "Failure of listing messages from memory msg store")
+    factory = cls(*params)
+    store = factory.get_store("a")
+    await store.start()
 
-        # Test list messages with text filter
-        msgs = self.loop.run_until_complete(chan.message_store.search(text="sage con"))
-        self.assertEqual(len(msgs), 2, "Failure of listing messages from memory msg store")
+    # try/finally to ensure cleanup
+    try:
+        assert await store.total() == 3
+        for k, entry in enumerate(await store.get_many(ids)):
+            assert entry["message"].payload == k
 
-        # Test view message
-        msg_content = self.loop.run_until_complete(chan.message_store.get_msg_content('%s' % msg5.uuid))
-        self.assertEqual(msg_content.payload, msg5.payload, "Failure of message %s view!" % msg5)
+    finally:
+        for store_id in factory.list_store():
+            await factory.delete_store(store_id)
 
-        # Test preview message
-        msg_content = self.loop.run_until_complete(chan.message_store.get_preview_str('%s' % msg5.uuid))
-        self.assertEqual(msg_content.payload, msg5.payload[:1000], "Failure of message %s preview!" % msg5)
 
-    def test_memory_message_store_store_id(self):
-        """
-            Test that store_id is correctly added to message's attrs and is correctly added to
-            yielded sub-messages
-        """
-        store_factory = msgstore.MemoryMessageStoreFactory()
+async def test_get_aliases_fake_coverage():
+    """Things that might not be needed anymore but are kept for now:
+    * get_preview_str
+    * get_msg_content
+    * get_payload_str
+    * is_regex_in_msg
+    * is_txt_in_msg
+    """
+    # same reasoning as for `search` tests; any store does it
+    store = msgstore.MemoryMessageStoreFactory().get_store("a")
+    await store.start()
 
-        # Basic chan
-        chan_name = "test_channel_mem_store_id"
-        chan = BaseChannel(
-            name=chan_name,
-            loop=self.loop,
-            message_store_factory=store_factory
+    id = await store.store(Message(payload={"banana": ["good"]}))
+
+    assert (await store.get_preview_str(id)).payload == str({"banana": ["good"]})
+    assert (await store.get_msg_content(id)).payload == {"banana": ["good"]}
+    assert await store.get_payload_str(id) == str({"banana": ["good"]})
+
+    assert await store.is_regex_in_msg(id, "b[an]+")
+    assert not await store.is_regex_in_msg(id, "0")
+    rose = None
+    try:
+        assert await store.is_regex_in_msg(id, ":)")
+    except BaseException as exc:
+        rose = exc
+    assert isinstance(rose, ReError), rose
+
+    assert await store.is_txt_in_msg(id, "oo")
+    assert not await store.is_txt_in_msg(id, "xx")
+
+
+async def test_span_select_many(factory: MessageStoreFactory):
+    """Test span selection:
+        * :meth:`MessageStore._span_select`
+        * :meth:`MessageStore.get_many`
+
+    As part of testing the search, stores must be able to provide
+    all the ids of message within a given time span. `get_many`
+    might be overriden so it is tested alongside.
+
+    Reminders:
+        we guarentee to `_span_select` implementations that:
+            * `start_dt < end_dt`;
+            * `self.total() != 0`.
+        we guarentee to `get_many` reimplementations that:
+            * `1 < len(ids)`;
+            * `self.total() != 0`.
+    """
+    store = factory.get_store("a")
+    await store.start()
+
+    # make a bunch of messages with sorted timestamps and non-sorted payloads
+    msgs = [Message(payload=char) for char in "123546798"]
+    msg = msgs[0]
+    first_dt = last_dt = msg.timestamp
+    for msg in msgs[1:]:
+        last_dt += timedelta(1)
+        msg.timestamp = last_dt
+    del msg
+
+    # store these but not in timestamp order (notice char in list above)
+    not_ts_sorted_msgs = sorted(msgs, key=lambda msg: msg.payload)
+    not_ts_sorted_ids = [await store.store(msg) for msg in not_ts_sorted_msgs]
+    # re-sort the ids by corresponding message timestamp
+    ids = [
+        id
+        for id, msg in sorted(
+            zip(not_ts_sorted_ids, not_ts_sorted_msgs),
+            key=lambda pair: pair[1].timestamp,
         )
-        yieldernode = nodes.YielderNode()
-        chan.add(yieldernode)
+    ]
+    # now `msgs` and `ids` are in correspondence; this whole bit above is to test
+    # the store even when messages may not have been stored in timestamp order
 
-        # Second chan with no msgstore configured
-        chan_name2 = "test_channel_wo_store"
-        chan2_wo_msgstore = BaseChannel(
-            name=chan_name2,
-            loop=self.loop
-        )
-        chan2_wo_msgstore.add(nodes.BaseNode())
+    async def tester(start_dt: datetime | None, end_dt: datetime | None, expect: slice):
+        "a tester walks into a bar- runs into a bar- crawls into a bar-"
+        sel = await store._span_select(start_dt, end_dt)
+        # this tests for both correct ids and correct ordering
+        assert sel == ids[expect]
+        # if enough elements, also test `get_many`
+        if 1 < len(sel):
+            many = await store.get_many(sel)
+            # (explicit loop, not with :func:`all` for better reporting)
+            for expected, actual in zip(msgs[expect], many):
+                # (only match the payload, rest is not this test's responsibility)
+                assert actual["message"].payload == expected.payload
 
-        data = [1, 2, 3]
-        msg = message.Message(payload=data)
-        assert msg.store_id is None
-        assert msg.store_chan_name is None
+    # span largely wide enough to select everything
+    await tester(first_dt - timedelta(5), last_dt + timedelta(5), slice(9))
+    # span outside before / outside after
+    await tester(first_dt - timedelta(10), first_dt - timedelta(1), slice(0))
+    await tester(last_dt + timedelta(1), last_dt + timedelta(10), slice(0))
+    # span with start/end only (hshift excludes the first/last 2)
+    await tester(first_dt + timedelta(1.5), None, slice(2, 9))
+    await tester(None, last_dt - timedelta(1.5), slice(-2))
+    # span with neither start nor end (should be everything)
+    await tester(None, None, slice(9))
+    # result should be start inclusive and end exclusive
+    await tester(msgs[2].timestamp, msgs[4].timestamp, slice(2, 4))
 
-        # Launch channel processing
-        self.start_channels()
-        result_generator_msg = self.loop.run_until_complete(chan.handle(msg))
-        assert msg.store_id is not None
-        assert msg.store_chan_name == chan_name
-        msg_store_id = msg.store_id
-        for entry in result_generator_msg:
-            # Pass the entry in the second chan wo msgstore to verify that the msg attrs
-            # are not modified by the second chan
-            rslt_msg = self.loop.run_until_complete(chan2_wo_msgstore.handle(entry))
-            assert rslt_msg.store_id == msg_store_id
-            assert rslt_msg.store_chan_name == chan_name
 
-    def test_memory_message_store_in_fork(self):
-        """ We can store a message in FileMessageStore """
+# for every search tests: the tested function is in base :class:`MessageStore`
+# which is abstract; :meth:`search` is not to be overriden, so we can pick any
+# (lightweight and easily cleaned) concrete implementing class
 
-        store_factory = msgstore.MemoryMessageStoreFactory()
 
-        chan = BaseChannel(name="test_channel10.25", loop=self.loop, message_store_factory=store_factory)
+async def test_search_dum_checks():
+    "Collection of not that bright tests for search."
+    store = msgstore.MemoryMessageStoreFactory().get_store("a")
+    await store.start()
 
-        n1 = TstNode()
-        n2 = TstNode()
-        n3 = TstNode()
-        n4 = TstNode()
+    # empty store
+    assert await store.search() == [], "search without group_by should be a list"
+    assert await store.search(group_by="state") == {}, "search with group_by should be a dict"
 
-        chan.add(n1, n2)
-        fork = chan.fork()
-        fork.add(n3)
+    await store.store(Message(payload=0))
 
-        self.assertTrue(isinstance(fork.message_store, msgstore.NullMessageStore))
+    # still supported for now (this test is not contractual)
+    await store.search(start_dt="2002 12")
+    await store.search(end_dt="2002-123 17:42")
 
-        whe = chan.when(True, message_store_factory=store_factory)
-        whe.add(n4)
+    # broken time spans
+    try:
+        await store.search(start_dt=datetime(5555, 1, 1), end_dt=datetime(5555, 1, 1))
+    except BaseException:
+        pass
+    else:
+        raise AssertionError("search should have not accepted parameters (same dt)")
+    try:
+        await store.search(start_dt=datetime(8888, 1, 1), end_dt=datetime(2222, 1, 1))
+    except BaseException:
+        pass
+    else:
+        raise AssertionError("search should have not accepted parameters (backward)")
 
-        self.assertTrue(isinstance(whe.message_store, msgstore.MemoryMessageStore))
 
-    def test_replay_from_memory_message_store(self):
-        """ We can store a message in FileMessageStore """
+async def test_search_hashtag_nofilter():
+    "Searches with no params are expected to return everything."
+    store = msgstore.MemoryMessageStoreFactory().get_store("a")
+    await store.start()
 
-        store_factory = msgstore.MemoryMessageStoreFactory()
+    list_ids = [await store.store(Message(payload=char)) for char in "123546798"]
+    ids = set(list_ids)
+    # sanity check that shouldn't be necessary; but this invarient is crucial for the rest of the test
+    assert len(ids) == 9, "sanity check oops; cannot test"
+    # change a few messages' state
+    await store.change_message_state(list_ids[3], Message.REJECTED)
+    await store.change_message_state(list_ids[7], Message.ERROR)
 
-        chan = BaseChannel(name="test_channel10.5", loop=self.loop, message_store_factory=store_factory)
+    found = await store.search()
+    assert isinstance(found, list), "search without group_by should be a list"
+    assert {entry["id"] for entry in found} == ids, found
 
-        n = TstNode()
+    # (remark: this is not a comprehensive `group_by` test! this test is
+    # only concerned with the fact that every message stored is returned;
+    # this is why we are fine with not caring about the actual groups)
+    found = await store.search(group_by="state")
+    assert isinstance(found, dict), "search with group_by should be a dict"
+    assert {entry["id"] for group in found.values() for entry in group} == ids, found
 
-        msg = generate_msg(with_context=True)
-        msg2 = generate_msg(timestamp=(1982, 11, 27, 12, 35))
 
-        chan.add(n)
+async def test_search_count_and_start_id():
+    "Tests `count` and `start_id`."
+    store = msgstore.MemoryMessageStoreFactory().get_store("a")
+    await store.start()
 
-        # Launch channel processing
-        self.start_channels()
-        self.loop.run_until_complete(chan.handle(msg))
-        self.loop.run_until_complete(chan.handle(msg2))
+    # make a bunch of messages with increasing timestamps (because we'll be ordering by timestamp)
+    msgs = [Message(payload=char) for char in "123546798"]
+    msg = msgs[0]
+    last_dt = msg.timestamp
+    for msg in msgs[1:]:
+        last_dt += timedelta(1)
+        msg.timestamp = last_dt
+    del msg
+    ids = [await store.store(msg) for msg in msgs]
 
-        msg_stored = list(self.loop.run_until_complete(chan.message_store.search()))
+    async def tester(
+        count: int,
+        start_id: str | None,
+        direction: Literal["+", "-"],  # easier to read at call site than True/False
+        expect_or_except: slice | type[BaseException],
+    ):
+        "a tester walks into a bar- runs into a bar- crawls into a bar-"
+        try:
+            found = await store.search(
+                count=count,
+                start_id=start_id,
+                order_by="-timestamp" if "-" == direction else "timestamp",
+            )
 
-        for msg in msg_stored:
-            print(msg)
+        except BaseException as rose:
+            if isinstance(expect_or_except, slice):
+                raise  # were not expecting an exception
+            assert isinstance(rose, expect_or_except), expect_or_except
+            return
 
-        self.assertEqual(len(msg_stored), 2, "Should be 2 messages in store!")
+        assert isinstance(expect_or_except, slice)
+        assert isinstance(found, list)  # (at this point, this is mostly for type hints)
+        expect = ids[expect_or_except]
+        if "-" == direction:
+            expect.reverse()
+        assert [entry["id"] for entry in found] == expect, found
 
-        self.loop.run_until_complete(chan.replay(msg_stored[0]['id']))
+    # big enough of a count should get all of them
+    await tester(42, None, "+", slice(9))
+    # count of zero
+    await tester(0, None, "+", slice(0))
+    # smaller count should return begining (resp. ending) if non reversed (resp. reversed)
+    await tester(4, None, "+", slice(4))  # .    [----     ]
+    await tester(4, None, "-", slice(5, 9))  # . [     ----]
+    # same idea but starting at a message
+    await tester(3, ids[3], "+", slice(4, 7))  # [    |--- ]
+    await tester(3, ids[4], "-", slice(1, 4))  # [ ---|    ]
+    # same again but with less results than count
+    await tester(3, ids[6], "+", slice(7, 9))  # [      |--]
+    await tester(3, ids[2], "-", slice(0, 2))  # [--|      ]
+    # 'out of range' start_id should throw
+    # (we use a made-up id which for this function acts the same as an existing but out of range id)
+    await tester(3, "$#!@", "+", ValueError)  # |[         ]
 
-        msg_stored = list(self.loop.run_until_complete(chan.message_store.search()))
-        self.assertEqual(len(msg_stored), 3, "Should be 3 messages in store!")
 
-    def test_file_message_store(self):
-        """ We can store a message in FileMessageStore """
+async def test_search_filter_order_group():
+    "Test all of filtering/ordering/grouping"
+    store = msgstore.MemoryMessageStoreFactory().get_store("a")
+    await store.start()
 
-        tempdir = tempfile.mkdtemp()
-        print(tempdir)
+    bunch: list[tuple[datetime, Any, dict[str, Any]]] = [
+        (
+            datetime(2000, 1, 1),
+            "ayo",
+            {"state": Message.PROCESSED, "one": "one", "two": ["ononn", "uouii"], "num": ["42"]},
+        ),
+        (
+            datetime(2000, 1, 2),
+            0,
+            {"state": Message.ERROR, "one": ["not", "today", "!"], "two": ["okiuki", "-"], "num": ["15"]},
+        ),
+        (
+            datetime(2000, 2, 1),
+            True,
+            {"state": Message.ERROR, "one": ["yesterday", "?", "one"], "num": ["12", "72"]},
+        ),
+        (
+            datetime(2001, 1, 2),
+            {9: 3 / 4},
+            {"state": Message.REJECTED, "one": [], "num": ["notnum.. sad"]},
+        ),
+        (
+            datetime(2001, 2, 1),
+            ["payload", "is", "a", "list"],
+            {"state": Message.PENDING, "one": [], "two": "ononn", "num": 37},
+        ),
+    ]
+    # with other tests covering for edge cases, this one can be way less ceremonious
+    ids: list[str] = []
+    for timestamp, payload, meta in bunch:
+        msg = Message(payload=payload)
+        msg.timestamp = timestamp
+        ids.append(await store._store(msg, meta))
+    store._cached_total = len(ids)
 
-        store_factory = msgstore.FileMessageStoreFactory(path=tempdir)
+    async def tester_filter(text: str | None, rtext: str | None, meta: dict[str, str], expect: set[int]):
+        "a-"
+        found = await store.search(text=text, rtext=rtext, meta=meta)
+        assert isinstance(found, list)  # (at this point, this is mostly for type hints)
+        assert {it["id"] for it in found} == {ids[k] for k in expect}, found
 
-        chan = BaseChannel(name="test_channel11", loop=self.loop, message_store_factory=store_factory)
+    async def tester_order(order_by: str, expect: list[int]):
+        "tester-"
+        found = await store.search(order_by=order_by)
+        assert isinstance(found, list)  # (at this point, this is mostly for type hints)
+        assert [it["id"] for it in found] == [ids[k] for k in expect], found
 
-        n = TstNode()
-        n_error = TstConditionalErrorNode()
+    async def tester_group(group_by: str, expect: dict[str, set[int]]):
+        "walks-"
+        found = await store.search(group_by=group_by)
+        assert isinstance(found, dict)  # (at this point, this is mostly for type hints)
+        ex = {g: {ids[k] for k in s} for g, s in expect.items()}
+        assert {g: {it["id"] for it in l} for g, l in found.items()} == ex, found
 
-        msg = generate_msg(with_context=True)
-        msg2 = generate_msg(timestamp=(1982, 11, 27, 12, 35), message_content="message content2")
-        msg3 = generate_msg(timestamp=(1982, 11, 28, 12, 35), message_content="message content3")
-        msg4 = generate_msg(timestamp=(1982, 11, 28, 14, 35), message_content="message_content4")
+    await tester_filter("ay", None, {}, {0, 4})
+    await tester_filter(None, "\\d", {}, {1, 3})
+    await tester_filter(None, None, {"exact_one": "one"}, {0, 2})
+    await tester_filter(None, None, {"text_one": "day"}, {1, 2})
+    await tester_filter(None, None, {"rtext_two": "(.).{2}\\1"}, {0, 1, 4})
+    # this start/end range is inclusive (idk y i did that...)
+    await tester_filter(None, None, {"start_num": "17"}, {0, 2, 4})
+    await tester_filter(None, None, {"end_num": "17"}, {1, 2})
+    # multiple filters combine with logical 'and'
+    await tester_filter(",", None, {"exact_one": "one"}, set())
+    await tester_filter(None, None, {"text_one": "day", "start_num": "22"}, {2}),
+    # filter on multiple meta values (a list) is an implicit logical 'or';
+    # specifying a range via start+end, with the message having ['12', '72']:
+    # * what you might be expecting:
+    #     12  [40   60]  72   -> not in
+    # * what it's actually doing:
+    #     12  [40   60   72   -> yes above
+    #     12   40   60]  72   -> yes below
+    #                           `> yes in
+    await tester_filter(None, None, {"start_num": "40", "end_num": "60"}, {0, 2}),
 
-        # This message should be in error
-        msg5 = generate_msg(timestamp=(1982, 11, 12, 14, 35),
-                            message_content='{"test1": "shall_fail"}')
-        msg6 = generate_msg(timestamp=(1982, 11, 28, 14, 35), message_content=ObjectWithoutStr())
-        chan.add(n)
-        chan.add(n_error)
+    await tester_order("timestamp", [0, 1, 2, 3, 4])
+    # not that these are not sorted by severity but alphabetically
+    # (then by timestamp because stable sort)
+    await tester_order("state", [1, 2, 4, 0, 3])
+    await tester_order("meta_one", [3, 4, 1, 0, 2])
+    await tester_order("-meta_one", [2, 0, 1, 4, 3])
 
-        # Launch channel processing
-        self.start_channels()
-        self.loop.run_until_complete(chan.handle(msg))
-        self.loop.run_until_complete(chan.handle(msg2))
-        self.loop.run_until_complete(chan.handle(msg3))
-        self.loop.run_until_complete(chan.handle(msg4))
-        with self.assertRaises(TstException):
-            # This message should be in error state
-            self.loop.run_until_complete(chan.handle(msg5))
-        self.loop.run_until_complete(chan.handle(msg6))
-
-        self.assertEqual(self.loop.run_until_complete(chan.message_store.total()),
-                         6, "Should be a total of 6 messages in store!")
-
-        msg_stored = list(self.loop.run_until_complete(chan.message_store.search()))
-        msg2_id = msg_stored[1]["id"]
-        msg_stored1 = list(self.loop.run_until_complete(chan.message_store.search(count=2)))
-        self.assertEqual(len(msg_stored1), 2, "Should be 2 results from search!")
-
-        msg_stored2 = list(self.loop.run_until_complete(chan.message_store.search(start_id=msg2_id, count=5)))
-        self.assertEqual(len(msg_stored2), 4, "Should be 4 results from search!")
-
-        # All message stored ?
-        self.assertEqual(len(msg_stored), 6, "Should be 6 messages in store!")
-
-        for msg in msg_stored:
-            print(msg)
-
-        for msg in msg_stored1 + msg_stored2:
-            print(msg)
-
-        ids1 = [msg['id'] for msg in msg_stored1 + msg_stored2]
-        ids2 = [msg['id'] for msg in msg_stored]
-
-        self.assertEqual(ids1, ids2, "Should be 5 messages in store!")
-
-        # Test processed message
-        dict_msg = self.loop.run_until_complete(
-            chan.message_store.get('19821128_123500000000_%s' % msg3.uuid))
-        self.assertEqual(dict_msg['state'], 'processed', "Message %s should be in processed state!" % msg3)
-
-        # Test failed message
-        dict_msg = self.loop.run_until_complete(
-            chan.message_store.get('19821112_143500000000_%s' % msg5.uuid))
-        self.assertEqual(dict_msg['state'], 'error', "Message %s should be in error state!" % msg5)
-
-        self.assertTrue(os.path.exists("%s/%s/1982/11/28/19821128_123500000000_%s"
-                        % (tempdir, chan.name, msg3.uuid)))
-
-        # Test list messages
-        msgs = self.loop.run_until_complete(chan.message_store.search(start_id=msg2_id, count=5))
-        self.assertEqual(len(msgs), 4, "Failure of listing messages for file msg store")
-
-        # Test list messages with date filters
-        msgs = self.loop.run_until_complete(chan.message_store.search(
-            start_dt="1982-11-27", end_dt="1982-11-28T13:00:00"))
-        self.assertEqual(len(msgs), 2, "Failure of listing messages for file msg store")
-
-        # Test list messages with text filters
-        msgs = self.loop.run_until_complete(chan.message_store.search(
-            text="sage con"))
-        self.assertEqual(len(msgs), 2, "Failure of listing messages for file msg store")
-
-        # Test list messages with regex filters
-        msgs = self.loop.run_until_complete(chan.message_store.search(
-            rtext="\w+_\w+"))  # noqa: W605
-        self.assertEqual(len(msgs), 1, "Failure of listing messages for file msg store")
-
-        # Test view message
-        msg_content = self.loop.run_until_complete(chan.message_store.get_msg_content(
-            '19821112_143500000000_%s' % msg5.uuid))
-        self.assertEqual(msg_content.payload, msg5.payload, "Failure of message %s view!" % msg5)
-
-        # Test preview message
-        msg_content = self.loop.run_until_complete(chan.message_store.get_preview_str(
-            '19821112_143500000000_%s' % msg5.uuid))
-        self.assertEqual(msg_content.payload, msg5.payload[:1000], "Failure of message %s preview!" % msg5)
-
-        self.clean_loop()
-
-        # TODO put in tear_down ?
-        shutil.rmtree(tempdir, ignore_errors=True)
-
-    def test_file_message_store_meta(self):
-        """Tests for meta in file message store"""
-        data_tst_path = Path(__file__).resolve().parent / "data"
-        old_meta_tst_path = data_tst_path / "old_meta.meta"
-        new_meta_tst_path = data_tst_path / "new_meta.meta"
-        with new_meta_tst_path.open("r") as fin:
-            new_meta_data = json.load(fin)
-        msg_uid = "msgid"
-        msg_year = "2024"
-        msg_month = "06"
-        msg_day = "13"
-        msg_date = f"{msg_year}{msg_month}{msg_day}"
-        msg_time = "0000"
-        msg_id = f"{msg_date}_{msg_time}_{msg_uid}"
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            store_factory = msgstore.FileMessageStoreFactory(path=tempdir)
-            store = store_factory.get_store(store_id="")
-            meta_dst_folder_path = Path(tempdir) / msg_year / msg_month / msg_day
-            meta_dst_folder_path.mkdir(parents=True, exist_ok=True)
-            meta_dst_path = meta_dst_folder_path / f"{msg_id}.meta"
-            shutil.copy(old_meta_tst_path, meta_dst_path)
-            # Tests that msgstore could read an old meta file
-            msg_state = asyncio.run(store.get_message_state(msg_id))
-            self.assertEqual(msg_state, "processed")
-            # Test that the old meta file is converted to a new json meta file
-            with meta_dst_path.open("r") as fin:
-                meta_data = json.load(fin)
-            self.assertDictEqual(new_meta_data, meta_data)
-
-    def test_search_meta_filter_sort(self):
-        """Retrieve, filter and sort messages based on meta info"""
-
-        results = [
-            {'id': str(k), 'message': Message(meta=meta)}  # trimmed version with only what we need
-            for k, meta in enumerate((
-                {
-                    'one': 'one',
-                    'two': ['uouii', 'ononn'],
-                    'num': ['42'],
-                },
-                {
-                    'one': ['not', 'today', '!'],
-                    'two': ['-', 'okiuki', '-'],
-                    'num': ['15'],
-                },
-                {
-                    'one': ['yesterday', '?'],
-                    'num': ['12', '72'],
-                },
-                {
-                    'one': [],
-                    'num': ['notnum.. sad'],
-                },
-                {
-                    'one': [],
-                    'num': 37,
-                },
-            ))
-        ]
-
-        # filt/ord by .. should yield .. (indices in list)
-        cases = [
-            ({'exact_one': 'one'}, [0]),
-            ({'text_one': 'day'}, [1, 2]),
-            ({'exact_two': 'okiuki'}, [1]),
-            ({'rtext_two': '(.).{2}\\1'}, [0, 1]),
-            ({'start_num': '17'}, [0, 2, 4]),
-            ({'end_num': '17'}, [1, 2]),
-            ({'text_one': 'day', 'start_num': '22'}, [2]),
-
-            # specifying a range via start+end, with the message having ['12', '72']:
-            # * what you might be expecting:
-            #     12  [40   60]  72   -> not in
-            # * what it's actually doing:
-            #     12  [40   60   72   -> yes above
-            #     12   40   60]  72   -> yes below
-            #                           `> yes in
-            ({'start_num': '40', 'end_num': '60'}, [0, 2]),
-
-            ({'order_by': 'num'}, [2, 1, 4, 0, 3]),
-            ({'order_by': '-num'}, [3, 0, 4, 1, 2]),
-
-            # no search param should forward all the results
-            ({}, list(range(len(results)))),
-        ]
-
-        for search, expect in cases:
-            actual = [
-                int(item['id'])
-                for item in
-                msgstore.MessageStore._search_meta_filter_sort(search, results)
-            ]
-            self.assertListEqual(expect, actual)
+    await tester_group(
+        "state",
+        {
+            Message.ERROR: {1, 2},
+            Message.PENDING: {4},
+            Message.PROCESSED: {0},
+            Message.REJECTED: {3},
+        },
+    )
+    await tester_group(
+        "meta_two",
+        {
+            "": {2, 3},
+            "ononn": {0, 4},
+            "okiuki": {1},
+        },
+    )

--- a/pypeman/tests/test_retrystore.py
+++ b/pypeman/tests/test_retrystore.py
@@ -228,7 +228,7 @@ class RetryStoreTests(TestCase):
         with self.assertRaises(exceptions.PausedChanException):
             self.loop.run_until_complete(chan.handle(msg))
         stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 1
         assert stored_msg["state"] == message.Message.WAIT_RETRY
@@ -246,7 +246,7 @@ class RetryStoreTests(TestCase):
         print("RETRY")
         # Retry without modifying nodes (same comportment as above, no modification)
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 1
         assert msgs_retry_store[0]["message"].payload == stored_msg["message"].payload
@@ -271,7 +271,7 @@ class RetryStoreTests(TestCase):
         # - Their payloads corresponds to element in input message's payload list
         init_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 3
         copied_msg_payload = copy.deepcopy(msg_payload)
@@ -307,7 +307,7 @@ class RetryStoreTests(TestCase):
 
         first_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 3
         copied_msg_payload = copy.deepcopy(msg_payload)
@@ -329,7 +329,7 @@ class RetryStoreTests(TestCase):
         assert forked_chan.status == BaseChannel.PAUSED
         assert forked_chan_retry_store.state == RetryFileMsgStore.RETRY_MODE
         assert conditional_chan.status == BaseChannel.WAITING
-        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(forked_chan_retry_store.search(order_by="timestamp"))
         assert len(msgs_retry_store) == 1
         msg_retry_store = msgs_retry_store[0]
@@ -356,7 +356,7 @@ class RetryStoreTests(TestCase):
         self.loop.run_until_complete(forked_chan_retry_store.retry())
         # Then relaunch other messages
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 3
         copied_msg_payload = copy.deepcopy(msg_payload)
@@ -378,7 +378,7 @@ class RetryStoreTests(TestCase):
         assert forked_chan.status == BaseChannel.WAITING
         assert forked_chan_retry_store.state == RetryFileMsgStore.STOPPED
         assert conditional_chan.status == BaseChannel.WAITING
-        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(forked_chan_retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(forked_chan_retry_store.search(order_by="timestamp"))
         assert len(msgs_retry_store) == 0
         stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
@@ -393,7 +393,7 @@ class RetryStoreTests(TestCase):
         # - The message have to be inject in join_node
         last_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 0
         assert chan.status == BaseChannel.WAITING
@@ -461,7 +461,7 @@ class RetryStoreTests(TestCase):
         with self.assertRaises(exceptions.PausedChanException):
             self.loop.run_until_complete(chan.handle(msg2))
         stored_msg2 = self.loop.run_until_complete(msgstore.get(id=msg2.uuid))
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 4
         assert stored_msg1["state"] == message.Message.WAIT_RETRY
@@ -495,7 +495,7 @@ class RetryStoreTests(TestCase):
         first_node.raise_exc = False
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 1
         assert msgs_retry_store[0]["message"].payload == msg_payload[-1]
@@ -523,7 +523,7 @@ class RetryStoreTests(TestCase):
         #   is in wait_retry state and must be inject in final_node
         join_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 1
         assert msgs_retry_store[0]["message"].payload == msg_payload
@@ -551,7 +551,7 @@ class RetryStoreTests(TestCase):
         # - The second message is processed, and state is set
         final_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 0
         assert chan.status == BaseChannel.WAITING
@@ -621,7 +621,7 @@ class RetryStoreTests(TestCase):
             self.loop.run_until_complete(chan.handle(msg))
         stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
         assert stored_msg["state"] == message.Message.WAIT_RETRY
-        cnt_msgs_cond_retrystore = self.loop.run_until_complete(cond_chan_retry_store.count_msgs())
+        cnt_msgs_cond_retrystore = self.loop.run_until_complete(cond_chan_retry_store.total())
         assert cnt_msgs_cond_retrystore == 1
         msg_cond_retry_store = self.loop.run_until_complete(
             cond_chan_retry_store.search(order_by="timestamp"))[0]
@@ -645,7 +645,7 @@ class RetryStoreTests(TestCase):
         # - The retry store of the conditional subchan is stopped
         conditional_node.exc = Rejected
         self.loop.run_until_complete(cond_chan_retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(cond_chan_retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(cond_chan_retry_store.total())
         assert cnt_msgs_retrystore == 0
         assert chan.status == BaseChannel.WAITING
         assert retry_store.state == RetryFileMsgStore.STOPPED
@@ -709,7 +709,7 @@ class RetryStoreTests(TestCase):
         with self.assertRaises(exceptions.PausedChanException):
             self.loop.run_until_complete(chan.handle(msg))
         stored_msg = self.loop.run_until_complete(msgstore.get(id=msg.uuid))
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         msgs_retry_store = self.loop.run_until_complete(retry_store.search(order_by="timestamp"))
         assert cnt_msgs_retrystore == 3
         copied_msg_payload = copy.deepcopy(msg_payload)
@@ -737,7 +737,7 @@ class RetryStoreTests(TestCase):
         # - The message state is ERROR
         first_node.raise_exc = False
         self.loop.run_until_complete(retry_store.retry())
-        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.count_msgs())
+        cnt_msgs_retrystore = self.loop.run_until_complete(retry_store.total())
         assert cnt_msgs_retrystore == 0
         assert chan.status == BaseChannel.WAITING
         assert retry_store.state == RetryFileMsgStore.STOPPED

--- a/pypeman/tests/tests_bin.py
+++ b/pypeman/tests/tests_bin.py
@@ -59,14 +59,7 @@ class BinPypemanTestCase(unittest.TestCase):
 
         return ret_code, data
 
-    def test_01_can_call_pypeman(self):
-        """ pypeman can be called without params """
-        logger.info("FILE = %r / NAME = %r", __file__, __name__)
-        cmd = self.cmd
-        self.run_pypeman(cmd)
-        self.run_pypeman(cmd, cwd=CWD)
-
-    def test_02_can_call_help(self):
+    def test_01_can_call_help(self):
         """ option -h is working """
         logger.info("FILE = %r / NAME = %r", __file__, __name__)
 
@@ -74,13 +67,13 @@ class BinPypemanTestCase(unittest.TestCase):
         self.run_pypeman(cmd)
         self.run_pypeman(cmd, cwd=CWD)
 
-    def test_03_can_call_graph(self):
+    def test_02_can_call_graph(self):
         """ subcommand graph is working """
 
         cmd = self.cmd + ['graph']
         self.run_pypeman(cmd, cwd=CWD)
 
-    def test_04_can_call_test(self):
+    def test_03_can_call_test(self):
         """ subcommand test is working """
 
         cmd = self.cmd + ['test']

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 python_files = test_*.py *_tests.py tests_*.py
 testpaths = pypeman
 norecursedirs = pypeman/client
-addopts = --junit-xml=nosetests.xml  --continue-on-collection-errors
+addopts = --junit-xml=nosetests.xml --continue-on-collection-errors
 # https://github.com/pytest-dev/pytest-asyncio
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = function


### PR DESCRIPTION
This is a rewrite of the message store to take advantage of inheritance.

Additions:
  * search's `group_by` parameter
  * factory `list_stores` and `delete_store` (it's used in testing)

Removals:
  * `FakeMessageStore` (and its factory); rational: reduction of API
    surface, `NullMessageStore` and explicit logging should be used
    instead when truly needed.
  * The search parameter `start` is no longer valid and is now an
    error; rational: it was deprecated in favor of `start_id` which
    is more usable and reliable from an API perspective.

Testing doesn't use a class because it doesn't work with pytest's
parameter fixtures. These are used to cover each store (including
any that would be added).

File line coverage is 96% (through `pypeman/tests/test_msgstore.py`);
two methods (expectedly) are not covered in here see below.

Semi-breaking changes:
  * For search, ordering by meta is done with `order_by="meta_.."`
    instead of the previous approach of having a `"order_by_.."` key
    in the meta filter dict (and so is grouping by meta). Rational:
    previous approach was allowing multiple ordering/grouping which
    msgstore will not be supporting.

Both of these above changes belong to not-yet-stabilized APIs.

Has not been re-written to take avantage of anything:
  * `add_sub_message_state` (other than the mentioned change above)
  * `set_state_to_worst_sub_state`
  * `retry.py` (&larr; is in dire need of something tho)

These two methods are not covered as part of the `test_msgstore.py`,
they are part of the `retrystore` system.
