### PR TITLE
FIX replay and inject in subchannels + lil tests cleanup

### DIFF
--- a/pypeman/channels.py
+++ b/pypeman/channels.py
@@ -472,7 +472,7 @@ class BaseChannel:
                 except exceptions.RetryException as retry_exc:
                     self.logger.info("%s CATCH RETRY in drop nodes for msg %s", str(self), str(msg))
                     retry_exc_catched = retry_exc
-            if self.raise_dropped:
+            if self.raise_dropped or self._has_callback():
                 raise
             return msg
         except Rejected as exc:
@@ -1152,7 +1152,7 @@ class SubChannel(BaseChannel):
             self.logger.info(
                 "subchan %s end process msg %s", str(self), str(entrymsg))
 
-    async def subhandle(self, msg, start_nodename=None):
+    async def handle(self, msg):
         msgctxvartoken = MSG_CTXVAR.set(msg.copy())
         ctx = contextvars.copy_context()
         copied_msg = msg.copy()
@@ -1161,7 +1161,7 @@ class SubChannel(BaseChannel):
             # of subchannel to the first message
             copied_msg.store_id = None
             copied_msg.store_chan_name = None
-        fut = asyncio.create_task(self.process(copied_msg, start_nodename=start_nodename))
+        fut = asyncio.create_task(super().handle(copied_msg))
         fut.add_done_callback(self._callback, context=ctx)
         self.parent.sub_chan_tasks.append(fut)
         MSG_CTXVAR.reset(msgctxvartoken)
@@ -1169,6 +1169,8 @@ class SubChannel(BaseChannel):
 
     async def process(self, msg, start_nodename=None):
         # https://github.com/mhcomm/pypeman/pull/319
+        # TODO: maybe the subchan_lock is no more useful since
+        # https://github.com/mhcomm/pypeman/pull/334
         async with self.subchan_lock:  # avoid having multiples message in parallel
             return await super().process(msg=msg, start_nodename=start_nodename)
 

--- a/pypeman/tests/test_channel.py
+++ b/pypeman/tests/test_channel.py
@@ -40,8 +40,12 @@ def raise_rejected(msg):
     raise Rejected()
 
 
+class MyException(Exception):
+    pass
+
+
 def raise_exc(msg):
-    raise Exception()
+    raise MyException()
 
 
 def return_text(msg, text):
@@ -205,7 +209,7 @@ class ChannelsTests(TestCase):
         n1.mock(output=raise_exc)
         self.start_channels()
         endnode._reset_test()
-        with self.assertRaises(Exception):
+        with self.assertRaises(MyException):
             self.loop.run_until_complete(chan1.handle(msg1))
 
         self.assertTrue(endnode.processed, "Channel fail_endnodes not working")
@@ -230,7 +234,7 @@ class ChannelsTests(TestCase):
         n1.mock(output=raise_exc)
         self.start_channels()
         endnode._reset_test()
-        with self.assertRaises(Exception):
+        with self.assertRaises(MyException):
             self.loop.run_until_complete(chan1.handle(msg1))
 
         self.assertTrue(endnode.processed, "Channel final_endnodes not working")
@@ -309,7 +313,7 @@ class ChannelsTests(TestCase):
         chan1._reset_test()
         n1.mock(output=raise_exc)
         self.start_channels()
-        with self.assertRaises(Exception):
+        with self.assertRaises(MyException):
             self.loop.run_until_complete(chan1.handle(msg1))
         self.assertTrue(
             n_endfail.processed,
@@ -421,7 +425,7 @@ class ChannelsTests(TestCase):
         chan1._reset_test()
         n3exc.mock(output=raise_exc)
         excmsg = generate_msg(message_content="exc")
-        with self.assertRaises(Exception):
+        with self.assertRaises(MyException):
             self.loop.run_until_complete(chan1.handle(excmsg))
         self.assertEqual(
             chan1_endfail.processed, 1,
@@ -574,7 +578,7 @@ class ChannelsTests(TestCase):
         chan1_endok._reset_test()
         chan1_endfinal._reset_test()
         startmsg = generate_msg(message_content="exc")
-        with self.assertRaises(Exception):
+        with self.assertRaises(MyException):
             self.loop.run_until_complete(chan1.handle(startmsg))
         self.assertTrue(
             chan1_endfail.processed,
@@ -683,7 +687,7 @@ class ChannelsTests(TestCase):
 
         startmsg = generate_msg(message_content="startmsg")
         self.start_channels()
-        with self.assertRaises(Exception) and self.assertRaises(Dropped):
+        with self.assertRaises((MyException, Dropped)):
             self.loop.run_until_complete(chan1.handle(startmsg))
 
         # chan1 : only ok and final end nodes have to be called
@@ -766,11 +770,11 @@ class ChannelsTests(TestCase):
             sub4_endok.processed,
             "subchan4 ok_endnodes called when nobody ask to him")
         self.assertFalse(
-            sub4_endok.processed,
+            sub4_endfail.processed,
             "subchan4 fail_endnodes called when nobody ask to him")
         self.assertTrue(
             sub4_enddrop.processed,
-            "subchan4 fail_endnodes not called")
+            "subchan4 drop_endnodes not called")
         sub4_enddrop_input = sub4_enddrop.last_input()
         self.assertFalse(sub4_enddrop_input.chan_rslt,
                          "subchan4 drop_nodes have rslt attr when it doesn't have to")


### PR DESCRIPTION
Bug: When a retry Exception occurs inside a subchannel, during the retry/inject phase the subchannel doesn't await its results that cause multiple tries instead of 1, and could also cause a retrystore start/stop loop

Cause: the BaseChannel inject method called the subhandle method, and the SubChannel subhandle was creating asyncio tasks.

Solution: Create subchannel tasks 1 level upper in the handle function to have only await and no more asyncio.create_task during the inject method (inject don't call handle)



+ mini fixs in tests + lil test cleanup ( MyException instead of python's Exception)